### PR TITLE
Fix combined refresh build, BG identifiers and failure verification

### DIFF
--- a/.github/workflows/livecontainer-build.yml
+++ b/.github/workflows/livecontainer-build.yml
@@ -2,9 +2,15 @@ name: LiveContainer embedded SideStore build
 
 on:
   workflow_dispatch:
+  push:
+    branches: [fix/combined-refresh-build-and-runtime]
 
 permissions:
   contents: read
+
+concurrency:
+  group: livecontainer-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   LIVE_CONTAINER_REF: 12377cf3b91d51739a33f14a302e5f522b238593
@@ -27,6 +33,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          mkdir -p artifacts/logs
           git clone --filter=blob:none https://github.com/LiveContainer/LiveContainer.git work/LiveContainer
           git -C work/LiveContainer checkout --detach "$LIVE_CONTAINER_REF"
           git -C work/LiveContainer submodule update --init --recursive --depth=1
@@ -66,19 +73,53 @@ jobs:
           test "$(git -C idevice rev-parse HEAD)" = "$IDEVICE_REF"
           test "$(git -C jktcp rev-parse HEAD)" = "$JKTCP_REF"
 
+      - name: Select Xcode 26.4
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: "26.4"
+
       - name: Run repository checks before patches
         env:
+          LIVE_CONTAINER_TEST_SOURCE: ${{ github.workspace }}/work/LiveContainer
           SIDESTORE_TEST_SOURCE: ${{ github.workspace }}/work/EmbeddedSideStore
           EMBEDDED_SIDESTORE_TEST_SOURCE: ${{ github.workspace }}/work/EmbeddedSideStore
         shell: bash
         run: |
           set -euo pipefail
-          python3 -m unittest discover -s builder/tests -v
+          python3 -m unittest discover -s builder/tests -v 2>&1 | tee artifacts/logs/repository-tests.log
 
-      - name: Select Xcode 26.4
-        uses: maxim-lobanov/setup-xcode@v1.6.0
-        with:
-          xcode-version: "26.4"
+      # Fail on generated Swift/configuration errors BEFORE compiling Rust/iOS.
+      - name: Apply and verify host integration
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            python3 builder/scripts/patch_livecontainer_autorefresh.py work/LiveContainer
+            python3 builder/scripts/patch_livecontainer_autorefresh.py work/LiveContainer
+            python3 builder/scripts/patch_embedded_sidestore_startup.py work/LiveContainer work/EmbeddedSideStore
+            python3 builder/scripts/patch_embedded_sidestore_startup.py work/LiveContainer work/EmbeddedSideStore
+            python3 - <<'PY'
+          import importlib.util
+          from pathlib import Path
+          spec = importlib.util.spec_from_file_location("background_patch", "builder/scripts/patch_background_automation.py")
+          module = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(module)
+          module.patch_background_operation(Path("work/EmbeddedSideStore"))
+          module.patch_console_log(Path("work/EmbeddedSideStore"))
+          PY
+            python3 builder/scripts/patch_combined_refresh_contract.py work/EmbeddedSideStore
+            python3 builder/scripts/patch_combined_refresh_contract.py work/EmbeddedSideStore
+            swiftc -frontend -parse work/LiveContainer/LiveContainerSwiftUI/App/AppDelegate.swift
+            swiftc -frontend -parse work/LiveContainer/LiveContainerSwiftUI/App/LiveContainerAutoRefreshAlarm.swift
+            swiftc -frontend -parse work/LiveContainer/LiveContainerSwiftUI/Views/Settings/LCEmbeddedSideStoreRefreshView.swift
+            swiftc -frontend -parse work/LiveContainer/SideStoreSupport/SideStore.swift
+            swiftc -frontend -parse work/EmbeddedSideStore/SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift
+            swiftc -frontend -parse work/EmbeddedSideStore/SideStore/Utils/iostreams/ConsoleLog.swift
+            swiftc -frontend -parse work/EmbeddedSideStore/AltStore/Core/Model/DatabaseManager/DatabaseManager.swift
+            plutil -lint work/LiveContainer/LiveContainer/Info.plist
+            plutil -extract BGTaskSchedulerPermittedIdentifiers.0 raw work/LiveContainer/LiveContainer/Info.plist
+            grep -Fq 'LIVE_REFRESH_LOG_RETENTION_V1' work/EmbeddedSideStore/SideStore/Utils/iostreams/ConsoleLog.swift
+          } 2>&1 | tee artifacts/logs/host-preflight.log
 
       - name: Install build tools
         run: |
@@ -92,10 +133,8 @@ jobs:
           set -euo pipefail
           python3 builder/scripts/patch_jktcp_reliability.py jktcp
           python3 builder/scripts/patch_coredevice_idevice.py idevice jktcp
-
           ! grep -R -E 'rppairing_connect_quic|create_quic_listener|quinn::' \
-            idevice/ffi/src/tunnel_provider.rs \
-            idevice/idevice/src/tunnel.rs
+            idevice/ffi/src/tunnel_provider.rs idevice/idevice/src/tunnel.rs
           grep -Fq 'packet.extend_from_slice(CDTUNNEL_MAGIC)' idevice/idevice/src/tunnel.rs
           grep -Fq 'effective_mss = negotiated_mtu.saturating_sub(60).min(1340)' idevice/ffi/src/tunnel_provider.rs
           grep -Fq 'HeartbeatClient::connect' idevice/ffi/src/tunnel_provider.rs
@@ -109,9 +148,7 @@ jobs:
           cargo fmt --manifest-path idevice/ffi/Cargo.toml
           git -C jktcp diff --check
           git -C idevice diff --check
-          cargo test --manifest-path jktcp/Cargo.toml --lib -- \
-            --skip tests::local_tcp \
-            --skip tests::handle_speed
+          cargo test --manifest-path jktcp/Cargo.toml --lib -- --skip tests::local_tcp --skip tests::handle_speed
           cargo check --manifest-path idevice/ffi/Cargo.toml --features obfuscate
 
       - name: Build idevice for iOS
@@ -120,28 +157,20 @@ jobs:
           set -euo pipefail
           BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$(xcrun --sdk iphoneos --show-sdk-path)" \
             IPHONEOS_DEPLOYMENT_TARGET=15.0 \
-            cargo build --release --target aarch64-apple-ios \
-              --features obfuscate --manifest-path ffi/Cargo.toml
-
+            cargo build --release --target aarch64-apple-ios --features obfuscate --manifest-path ffi/Cargo.toml
           test -f target/aarch64-apple-ios/release/libidevice_ffi.a
           test -f ffi/idevice.h
           grep -Fq 'tunnel_create_usb' ffi/idevice.h
           grep -Fq 'tunnel_heartbeat_is_active' ffi/idevice.h
           grep -Fq 'idevice_set_transport_log_callback' ffi/idevice.h
-          # Apple nm cannot read LLVM metadata in some Rust compiler_builtins
-          # members, but it still emits symbols from the FFI members we need.
           xcrun nm -arch arm64 -g target/aarch64-apple-ios/release/libidevice_ffi.a \
             >/tmp/current-idevice-symbols.txt 2>/tmp/current-nm-reader-warnings.txt || true
-          grep -E '[[:space:]][Tt][[:space:]]_lockdown_diag_rust_log$' \
-            /tmp/current-idevice-symbols.txt
-          grep -E '[[:space:]][Tt][[:space:]]_idevice_set_transport_log_callback$' \
-            /tmp/current-idevice-symbols.txt
+          grep -E '[[:space:]][Tt][[:space:]]_lockdown_diag_rust_log$' /tmp/current-idevice-symbols.txt
+          grep -E '[[:space:]][Tt][[:space:]]_idevice_set_transport_log_callback$' /tmp/current-idevice-symbols.txt
           rm -rf swift/IDevice.xcframework
           cp ffi/idevice.h swift/include/idevice.h
-          xcodebuild -create-xcframework \
-            -library target/aarch64-apple-ios/release/libidevice_ffi.a \
-            -headers swift/include \
-            -output swift/IDevice.xcframework
+          xcodebuild -create-xcframework -library target/aarch64-apple-ios/release/libidevice_ffi.a \
+            -headers swift/include -output swift/IDevice.xcframework
 
       - name: Patch combined transport and inject local idevice
         shell: bash
@@ -151,7 +180,6 @@ jobs:
           mkdir -p "$MUX/DeviceGateway/LocalBinary"
           rm -rf "$MUX/DeviceGateway/LocalBinary/IDevice.xcframework"
           cp -R idevice/swift/IDevice.xcframework "$MUX/DeviceGateway/LocalBinary/IDevice.xcframework"
-
           python3 builder/scripts/patch_combined_transport.py "$MUX"
           python3 builder/scripts/patch_local_idevice_package.py "$MUX"
           git -C "$MUX" diff --binary >"$RUNNER_TEMP/combined-transport-first.diff"
@@ -163,58 +191,19 @@ jobs:
           cmp "$RUNNER_TEMP/combined-transport-first.diff" "$RUNNER_TEMP/combined-transport-second.diff"
           cmp "$RUNNER_TEMP/combined-swift-first.txt" "$RUNNER_TEMP/combined-swift-second.txt"
           git -C "$MUX" diff --check
-
-          while IFS= read -r -d '' source; do
-            swiftc -frontend -parse "$source"
-          done < <(find "$MUX" -type f -name '*.swift' -not -path '*/.build/*' -print0)
+          while IFS= read -r -d '' source; do swiftc -frontend -parse "$source"; done < <(find "$MUX" -type f -name '*.swift' -not -path '*/.build/*' -print0)
           swift package --package-path "$MUX/DeviceGateway" dump-package >"$RUNNER_TEMP/combined-gateway-package.json"
-
-      - name: Apply and verify host integration
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 builder/scripts/patch_livecontainer_autorefresh.py work/LiveContainer
-          python3 builder/scripts/patch_livecontainer_autorefresh.py work/LiveContainer
-          python3 builder/scripts/patch_embedded_sidestore_startup.py work/LiveContainer work/EmbeddedSideStore
-          python3 builder/scripts/patch_embedded_sidestore_startup.py work/LiveContainer work/EmbeddedSideStore
-          python3 - <<'PY'
-          import importlib.util
-          from pathlib import Path
-
-          spec = importlib.util.spec_from_file_location(
-              "background_patch", "builder/scripts/patch_background_automation.py"
-          )
-          module = importlib.util.module_from_spec(spec)
-          spec.loader.exec_module(module)
-          module.patch_background_operation(Path("work/EmbeddedSideStore"))
-          module.patch_console_log(Path("work/EmbeddedSideStore"))
-          PY
-          swiftc -frontend -parse work/LiveContainer/LiveContainerSwiftUI/App/AppDelegate.swift
-          swiftc -frontend -parse work/LiveContainer/LiveContainerSwiftUI/App/LiveContainerAutoRefreshAlarm.swift
-          swiftc -frontend -parse work/LiveContainer/LiveContainerSwiftUI/Views/Settings/LCEmbeddedSideStoreRefreshView.swift
-          swiftc -frontend -parse work/LiveContainer/SideStoreSupport/SideStore.swift
-          swiftc -frontend -parse work/EmbeddedSideStore/SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift
-          swiftc -frontend -parse work/EmbeddedSideStore/SideStore/Utils/iostreams/ConsoleLog.swift
-          swiftc -frontend -parse work/EmbeddedSideStore/AltStore/Core/Model/DatabaseManager/DatabaseManager.swift
-          plutil -extract BGTaskSchedulerPermittedIdentifiers.0 raw work/LiveContainer/LiveContainer/Info.plist
-          xcodebuild -list -project work/LiveContainer/LiveContainer.xcodeproj
-          rm -rf "$HOME/Library/Caches/org.swift.swiftpm/artifacts/https___github_com_krzyzanowskim_OpenSSL_releases_download_3_6_2000_OpenSSL_xcframework_zip"
-          rm -rf "$HOME/Library/Developer/Xcode/DerivedData"/*/SourcePackages/artifacts/openssl
-          test -f work/EmbeddedSideStore/AltStore.xcodeproj/project.pbxproj
-          grep -Fq 'LIVE_REFRESH_LOG_RETENTION_V1' work/EmbeddedSideStore/SideStore/Utils/iostreams/ConsoleLog.swift
 
       - name: Build host and embedded SideStore source targets
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p artifacts/logs
+          rm -rf "$HOME/Library/Caches/org.swift.swiftpm/artifacts/https___github_com_krzyzanowskim_OpenSSL_releases_download_3_6_2000_OpenSSL_xcframework_zip"
+          rm -rf "$HOME/Library/Developer/Xcode/DerivedData"/*/SourcePackages/artifacts/openssl
           xcodebuild -project work/LiveContainer/LiveContainer.xcodeproj \
             -scheme LiveContainer -sdk iphoneos -configuration Release \
             -derivedDataPath "$RUNNER_TEMP/livecontainer-derived-data" \
-            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build \
-            2>&1 | tee artifacts/logs/livecontainer-build.log
-          rm -rf "$HOME/Library/Caches/org.swift.swiftpm/artifacts/https___github_com_krzyzanowskim_OpenSSL_releases_download_3_6_2000_OpenSSL_xcframework_zip"
-          rm -rf "$HOME/Library/Developer/Xcode/DerivedData"/*/SourcePackages/artifacts/openssl
+            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build 2>&1 | tee artifacts/logs/livecontainer-build.log
           artifact="$HOME/Library/Caches/org.swift.swiftpm/artifacts/https___github_com_krzyzanowskim_OpenSSL_releases_download_3_6_2000_OpenSSL_xcframework_zip"
           resolved=0
           for attempt in 1 2 3; do
@@ -223,30 +212,27 @@ jobs:
             rm -rf "$RUNNER_TEMP/embedded-sidestore-derived-data/SourcePackages/artifacts/openssl"
             if xcodebuild -resolvePackageDependencies -disablePackageRepositoryCache \
                 -project work/EmbeddedSideStore/AltStore.xcodeproj -scheme SideStore \
-                -derivedDataPath "$RUNNER_TEMP/embedded-sidestore-derived-data"; then
-              resolved=1
-              break
-            fi
+                -derivedDataPath "$RUNNER_TEMP/embedded-sidestore-derived-data"; then resolved=1; break; fi
             sleep 2
           done
           test "$resolved" -eq 1
           xcodebuild -project work/EmbeddedSideStore/AltStore.xcodeproj \
             -scheme SideStore -sdk iphoneos -configuration Release \
             -derivedDataPath "$RUNNER_TEMP/embedded-sidestore-derived-data" \
-            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build \
-            2>&1 | tee artifacts/logs/embedded-sidestore-build.log
+            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build 2>&1 | tee artifacts/logs/embedded-sidestore-build.log
 
       - name: Package and verify combined LiveContainer plus SideStore
         shell: bash
         run: |
           set -euo pipefail
-          brew install ldid
           python3 builder/scripts/package_livecontainer_combined.py \
             --root work/LiveContainer \
             --host "$RUNNER_TEMP/livecontainer-derived-data/Build/Products/Release-iphoneos/LiveContainer.app" \
             --side "$RUNNER_TEMP/embedded-sidestore-derived-data/Build/Products/Release-iphoneos/SideStore.app" \
-            --output artifacts/LiveContainer-SideStore-AutoRefresh.ipa \
-            2>&1 | tee artifacts/logs/combined-packaging.log
+            --output artifacts/LiveContainer-SideStore-AutoRefresh.ipa 2>&1 | tee artifacts/logs/combined-packaging.log
+          python3 builder/scripts/patch_combined_refresh_contract.py --verify-ipa artifacts/LiveContainer-SideStore-AutoRefresh.ipa \
+            2>&1 | tee artifacts/logs/runtime-contract-verification.log
+          printf 'builder_commit=%s\n' "$GITHUB_SHA" > artifacts/builder-commit.txt
 
       - name: Verify embedded CoreDevice transport executable
         shell: bash
@@ -255,26 +241,19 @@ jobs:
           python3 - <<'PY'
           from pathlib import Path
           import zipfile
-
           ipa = Path('artifacts/LiveContainer-SideStore-AutoRefresh.ipa')
-          # This is the executable path verified by package_livecontainer_combined.py.
           embedded = 'Payload/LiveContainer.app/Frameworks/SideStoreApp.framework/SideStore'
           with zipfile.ZipFile(ipa) as archive:
               executable = archive.read(embedded)
           assert executable[:4] == b'\xcf\xfa\xed\xfe', 'Expected embedded arm64 Mach-O'
           assert b'no ipsec interface (required for lockdown on iOS 26.4+)' not in executable, 'Obsolete IPSec guard remains'
-          markers = (
-              '[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED',
-              '[SIDESTORE_COREDEVICE] TRANSPORT_CREATE_PASS',
-              '[SIDESTORE_COREDEVICE] ENDPOINT_SELECT',
-              '[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED',
-              '[SIDESTORE_COREDEVICE] JKTCP_MSS_CONFIG',
-          )
+          markers = ('[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED', '[SIDESTORE_COREDEVICE] TRANSPORT_CREATE_PASS',
+                     '[SIDESTORE_COREDEVICE] ENDPOINT_SELECT', '[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED',
+                     '[SIDESTORE_COREDEVICE] JKTCP_MSS_CONFIG')
           for marker in markers:
               assert marker.encode() in executable, f'Embedded transport marker missing: {marker}'
           Path('artifacts/logs/embedded-transport-verification.txt').write_text(
-              f'executable={embedded}\n' + '\n'.join(markers) + '\nverification=PASS\n'
-          )
+              f'executable={embedded}\n' + '\n'.join(markers) + '\nverification=PASS\n')
           PY
 
       - name: Upload combined LiveContainer IPA
@@ -284,6 +263,8 @@ jobs:
           path: |
             artifacts/LiveContainer-SideStore-AutoRefresh.ipa
             artifacts/LiveContainer-SideStore-AutoRefresh.verification.json
+            artifacts/LiveContainer-SideStore-AutoRefresh.runtime-verification.json
+            artifacts/builder-commit.txt
           if-no-files-found: error
           compression-level: 0
           retention-days: 7
@@ -293,6 +274,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: livecontainer-autorefresh-build-evidence
-          path: artifacts
+          path: artifacts/logs
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/livecontainer-build.yml
+++ b/.github/workflows/livecontainer-build.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: livecontainer-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   LIVE_CONTAINER_REF: 12377cf3b91d51739a33f14a302e5f522b238593

--- a/scripts/patch_combined_refresh_contract.py
+++ b/scripts/patch_combined_refresh_contract.py
@@ -23,7 +23,7 @@ def patch(root: Path) -> None:
         'defaults.set(defaults.string(forKey: "liveContainerAutoRefreshExpectedRunID") ?? refreshIdentifier,\n                     forKey: "liveContainerAutoRefreshHostHandoffRunID")')
     text = replace_once(text,
         'defaults.set(["version": 1, "date": Date(),',
-        '// COMBINED_REFRESH_MANIFEST_V2: omissions are not verified success.\n        defaults.set(["version": 2, "date": Date(),\n            "expected_ids": installedApps.map { $0.bundleIdentifier },')
+        '// COMBINED_REFRESH_MANIFEST_V2: omissions are not verified success.\n        defaults.set(["version": 2, "date": Date(),\n            "schema": "LiveContainerRefreshManifestV2",\n            "expected_ids": installedApps.map { $0.bundleIdentifier },')
     # The existing helper is itself a raw Python string; its diagnostic Swift
     # must interpolate values rather than print backslash-parenthesis literally.
     start = text.index("    private func automaticRefreshDefaults()")
@@ -58,7 +58,7 @@ def verify_ipa(path: Path) -> dict:
         assert len(tasks) == 1 and tasks[0] + ".watchdog" in allowed
         assert tuple(map(int, info.get("MinimumOSVersion", "999").split("."))) <= (15, 0, 0)
         embedded = archive.read(base + "/Frameworks/SideStoreApp.framework/SideStore")
-        assert b"expected_ids" in embedded, "Incomplete-result verification contract not embedded"
+        assert b"LiveContainerRefreshManifestV2" in embedded, "Incomplete-result verification contract not embedded"
         for name in archive.namelist():
             if name.endswith("/"):
                 continue

--- a/scripts/patch_combined_refresh_contract.py
+++ b/scripts/patch_combined_refresh_contract.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Align embedded verification with the host's run identity; combined build only."""
+from pathlib import Path
+import sys
+
+MARKER = "COMBINED_REFRESH_MANIFEST_V2"
+
+
+def replace_once(text: str, old: str, new: str) -> str:
+    if text.count(old) != 1:
+        raise SystemExit(f"combined refresh contract: expected one anchor: {old[:100]!r}")
+    return text.replace(old, new, 1)
+
+
+def patch(root: Path) -> None:
+    path = root / "SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift"
+    text = path.read_text(encoding="utf-8")
+    if MARKER in text:
+        verify(text)
+        return
+    text = replace_once(text,
+        'defaults.set(refreshIdentifier, forKey: "liveContainerAutoRefreshHostHandoffRunID")',
+        'defaults.set(defaults.string(forKey: "liveContainerAutoRefreshExpectedRunID") ?? refreshIdentifier,\n                     forKey: "liveContainerAutoRefreshHostHandoffRunID")')
+    text = replace_once(text,
+        'defaults.set(["version": 1, "date": Date(),',
+        '// COMBINED_REFRESH_MANIFEST_V2: omissions are not verified success.\n        defaults.set(["version": 2, "date": Date(),\n            "expected_ids": installedApps.map { $0.bundleIdentifier },')
+    # The existing helper is itself a raw Python string; its diagnostic Swift
+    # must interpolate values rather than print backslash-parenthesis literally.
+    start = text.index("    private func automaticRefreshDefaults()")
+    end = text.index("    private func startListeningForRunningApps()", start)
+    section = text[start:end].replace(r"\\(", r"\(")
+    text = text[:start] + section + text[end:]
+    verify(text)
+    path.write_text(text, encoding="utf-8")
+
+
+def verify(text: str) -> None:
+    for needle in (MARKER, '"expected_ids": installedApps.map',
+                   'defaults.string(forKey: "liveContainerAutoRefreshExpectedRunID") ?? refreshIdentifier'):
+        if needle not in text:
+            raise SystemExit(f"combined refresh contract missing {needle}")
+
+
+def verify_ipa(path: Path) -> dict:
+    import hashlib
+    import json
+    import plistlib
+    import struct
+    import zipfile
+    base = "Payload/LiveContainer.app"
+    images = []
+    with zipfile.ZipFile(path) as archive:
+        info = plistlib.loads(archive.read(base + "/Info.plist"))
+        assert info.get("LCRefreshContractVersion") == 2, "Unpatched host configuration"
+        assert {"fetch", "processing"} <= set(info.get("UIBackgroundModes", []))
+        allowed = info.get("BGTaskSchedulerPermittedIdentifiers", [])
+        tasks = [x for x in allowed if x.endswith(".sidestore.automatic-refresh")]
+        assert len(tasks) == 1 and tasks[0] + ".watchdog" in allowed
+        assert tuple(map(int, info.get("MinimumOSVersion", "999").split("."))) <= (15, 0, 0)
+        embedded = archive.read(base + "/Frameworks/SideStoreApp.framework/SideStore")
+        assert b"expected_ids" in embedded, "Incomplete-result verification contract not embedded"
+        for name in archive.namelist():
+            if name.endswith("/"):
+                continue
+            with archive.open(name) as stream:
+                magic = stream.read(4)
+            if magic != b"\xcf\xfa\xed\xfe":
+                continue
+            image = archive.read(name)
+            count = struct.unpack_from("<I", image, 16)[0]
+            offset = 32
+            alarm = None
+            for _ in range(count):
+                if offset + 8 > len(image):
+                    raise ValueError(f"Truncated Mach-O load commands: {name}")
+                command, size = struct.unpack_from("<II", image, offset)
+                if size < 8 or offset + size > len(image):
+                    raise ValueError(f"Malformed Mach-O load command: {name}")
+                if command in (0xC, 0x80000018, 0x8000001F):
+                    start = struct.unpack_from("<I", image, offset + 8)[0]
+                    library = image[offset + start:offset + size].split(b"\0", 1)[0]
+                    if b"AlarmKit.framework/AlarmKit" in library:
+                        assert command == 0x80000018, f"Hard AlarmKit dependency: {name}"
+                        alarm = "weak"
+                offset += size
+            images.append({"image": name, "alarmkit": alarm or "absent"})
+    assert images, "No arm64 images were inspected"
+    result = {"runtime_contract": 2, "configuration": "passed", "alarmkit_linkage": images,
+              "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+              "device_runtime": "NOT TESTED; requires signed on-device validation"}
+    output = path.with_suffix(".runtime-verification.json")
+    output.write_text(json.dumps(result, indent=2) + "\n")
+    return result
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 3 and sys.argv[1] == "--verify-ipa":
+        result = verify_ipa(Path(sys.argv[2]))
+        print("Combined runtime package verification passed; device runtime NOT TESTED")
+        print("SHA256=" + result["sha256"])
+    elif len(sys.argv) == 2:
+        patch(Path(sys.argv[1]))
+    else:
+        raise SystemExit("usage: patch_combined_refresh_contract.py <embedded-root> | --verify-ipa <file.ipa>")

--- a/scripts/patch_livecontainer_autorefresh.py
+++ b/scripts/patch_livecontainer_autorefresh.py
@@ -1,20 +1,49 @@
 #!/usr/bin/env python3
-"""Integrate host-owned scheduled refresh into pinned LiveContainer sources.
+"""Integrate host-owned refresh without embedding Swift in Python f-strings.
 
-The embedded SideStore process cannot own BGTaskScheduler registration: iOS
-registers background tasks against the containing LiveContainer application.
-This patch keeps the existing LiveProcess/XPC refresh bridge and moves the
-task registration, schedule UI, and persisted result state into the host.
+Templates are ordinary Swift files, parsed in preflight and tested as generated
+sources. The host uses its installed BG allowlist, not an assumed signer rewrite.
+Transport and the upstream combined packaging engine are left unchanged.
 """
-
 from __future__ import annotations
 
 from pathlib import Path
+import plistlib
+import shutil
+import subprocess
 import sys
-
 
 TASK_ID = "com.kdt.livecontainer.sidestore.automatic-refresh"
 MARKER = "[LIVE_CONTAINER_REFRESH] REGISTER_PASS"
+TEMPLATES = Path(__file__).resolve().parent / "templates"
+
+
+def template(name: str) -> str:
+    return (TEMPLATES / name).read_text(encoding="utf-8")
+
+
+HOST_SCHEDULER = template("livecontainer_refresh_policy.swift") + "\n" + template("livecontainer_refresh_scheduler.swift")
+ALARM_PROVIDER = template("livecontainer_refresh_alarm.swift")
+SETTINGS_VIEW = template("livecontainer_refresh_settings.swift")
+BRIDGE = r'''
+// LC_REFRESH_BRIDGE_V2_BEGIN
+/// Use the action identity present in the combined package's intent metadata.
+public enum LiveContainerRefreshBridge {
+    public static func refreshAllApps() async throws {
+        guard #available(iOS 17.0, *) else {
+            throw NSError(domain: "LiveContainerRefresh.UnsupportedOS", code: 17,
+                userInfo: [NSLocalizedDescriptionKey: "The embedded automatic refresh bridge requires iOS 17 or later."])
+        }
+        try Task.checkCancellation()
+        try await RefreshHandler.shared.startRefresh(
+            identifier: "RefreshAllIntent",
+            mangledName: "16SideStoreSupport20RefreshAllAppsIntentV"
+        )
+        try Task.checkCancellation()
+    }
+}
+// LC_REFRESH_BRIDGE_V2_END
+'''
 
 
 def die(message: str) -> None:
@@ -23,659 +52,124 @@ def die(message: str) -> None:
 
 def replace_once(text: str, old: str, new: str, label: str) -> str:
     count = text.count(old)
-    if count == 0:
-        die(f"missing {label}")
-    if count > 1:
-        die(f"ambiguous {label}: {count} matches")
+    if count != 1:
+        die(f"{label}: expected one anchor, found {count}")
     return text.replace(old, new, 1)
 
 
-BRIDGE = r'''
-
-/// Narrow host-facing bridge. The refresh still executes in the embedded
-/// SideStore through the existing LiveProcess/XPC path.
-public enum LiveContainerRefreshBridge {
-    public static func refreshAllApps() async throws {
-        try await RefreshHandler.shared.startRefresh(
-            identifier: "LiveContainerScheduledRefresh",
-            mangledName: "16SideStoreSupport20RefreshAllAppsIntentV"
-        )
-    }
-}
-'''
-
-
-HOST_SCHEDULER = rf'''
-
-enum LiveContainerAutoRefreshScheduler {{
-    // The initial signer rewrites the permitted identifiers from the original
-    // host ID. Build the runtime IDs from that signed host ID as well.
-    static let taskIdentifier = "\(Bundle.main.bundleIdentifier ?? \"com.kdt.livecontainer\").sidestore.automatic-refresh"
-    static let watchdogIdentifier = "\(taskIdentifier).watchdog"
-    static let defaults = UserDefaults(suiteName: "group.com.SideStore.SideStore") ?? .standard
-    static let enabledKey = "liveContainerAutoRefreshEnabled"
-    static let frequencyKey = "liveContainerAutoRefreshFrequency"
-    static let weekdayKey = "liveContainerAutoRefreshWeekday"
-    static let minutesKey = "liveContainerAutoRefreshMinutes"
-    static let lastResultKey = "liveContainerAutoRefreshLastResult"
-    static let lastDateKey = "liveContainerAutoRefreshLastDate"
-    static let historyKey = "liveContainerAutoRefreshHistory"
-    static let earliestEligibleKey = "liveContainerAutoRefreshEarliestEligibleAt"
-    static let deadlineKey = "liveContainerAutoRefreshTargetDeadline"
-    static let nextRetryKey = "liveContainerAutoRefreshNextRetryAt"
-    static let lastTaskKey = "liveContainerAutoRefreshLastTaskTrigger"
-    static let lastAttemptKey = "liveContainerAutoRefreshLastAttempt"
-    static let activeRunKey = "liveContainerAutoRefreshActiveRunID"
-    static let retryCountKey = "liveContainerAutoRefreshRetryCount"
-    static let hostHandoffKey = "liveContainerAutoRefreshHostHandoff"
-    static let hostHandoffRunKey = "liveContainerAutoRefreshHostHandoffRunID"
-    static let hostHandoffStartedKey = "liveContainerAutoRefreshHostHandoffStartedAt"
-    static let hostPreviousExpirationKey = "liveContainerAutoRefreshHostPreviousExpiration"
-    static let verificationKey = "liveContainerAutoRefreshVerification"
-    static let expectedRunKey = "liveContainerAutoRefreshExpectedRunID"
-    static let hostVerifiedKey = "liveContainerAutoRefreshHostVerifiedAfterRelaunch"
-    static let strategyKey = "liveContainerAutoRefreshStrategy"
-    static let alarmScheduledKey = "liveContainerAutoRefreshAlarmScheduled"
-    static let alarmDeadlineKey = "liveContainerAutoRefreshAlarmDeadline"
-    static let healthStateKey = "liveContainerAutoRefreshHealthState"
-    static let lastErrorKey = "liveContainerAutoRefreshLastError"
-    static let lastSuccessfulKey = "liveContainerAutoRefreshLastSuccessfulRefresh"
-    static let leadTime: TimeInterval = 60 * 60
-    static let coalescingWindow: TimeInterval = 60
-    private static let lock = NSLock()
-
-    static func requestNotificationPermission() {{
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) {{ granted, error in
-            if let error {{
-                print("[LIVE_CONTAINER_REFRESH] NOTIFICATION_PERMISSION_FAIL error=\\(error.localizedDescription)")
-            }} else {{
-                print("[LIVE_CONTAINER_REFRESH] NOTIFICATION_PERMISSION granted=\\(granted)")
-            }}
-        }}
-    }}
-
-    private static func notify(title: String, body: String, kind: String) {{
-        UNUserNotificationCenter.current().getNotificationSettings {{ settings in
-            guard settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional else {{
-                print("[LIVE_CONTAINER_REFRESH] NOTIFICATION_SKIPPED kind=\\(kind) reason=not_authorized")
-                return
-            }}
-            let content = UNMutableNotificationContent()
-            content.title = title
-            content.body = body
-            content.sound = .default
-            let request = UNNotificationRequest(
-                identifier: "LiveContainerAutoRefresh.\\(kind).\\(UUID().uuidString)",
-                content: content,
-                trigger: nil
-            )
-            UNUserNotificationCenter.current().add(request) {{ error in
-                if let error {{
-                    print("[LIVE_CONTAINER_REFRESH] NOTIFICATION_FAIL kind=\\(kind) error=\\(error.localizedDescription)")
-                }} else {{
-                    print("[LIVE_CONTAINER_REFRESH] NOTIFICATION_PASS kind=\\(kind)")
-                }}
-            }}
-        }}
-    }}
-
-    private static func diagnosticDate(_ date: Date, timeZone: TimeZone) -> String {{
-        let formatter = ISO8601DateFormatter()
-        formatter.timeZone = timeZone
-        return formatter.string(from: date)
-    }}
-
-    private static func cancelDeadlineAlarm() {{
-        if #available(iOS 26.1, *) {{
-            LiveContainerAutoRefreshAlarmProvider.cancelIfAvailable()
-        }}
-        defaults.set(false, forKey: alarmScheduledKey)
-    }}
-
-    private static func record(source: String, result: String, detail: String = "") {{
-        let entry: [String: String] = [
-            "date": ISO8601DateFormatter().string(from: Date()),
-            "source": source,
-            "result": result,
-            "detail": String(detail.prefix(300))
-        ]
-        var history = defaults.array(forKey: historyKey) as? [[String: String]] ?? []
-        history.insert(entry, at: 0)
-        defaults.set(Array(history.prefix(50)), forKey: historyKey)
-        defaults.set(result, forKey: lastResultKey)
-        defaults.set(Date(), forKey: lastDateKey)
-        NotificationCenter.default.post(name: Notification.Name("LiveContainerAutoRefreshHistoryChanged"), object: nil)
-    }}
-
-    private static func compactWorkIsDue(now: Date) -> Bool {{
-        if defaults.object(forKey: earliestEligibleKey) == nil {{ return true }}
-        if defaults.bool(forKey: hostHandoffKey) {{ return false }}
-        if let retry = defaults.object(forKey: nextRetryKey) as? Date, retry > now {{ return false }}
-        if let eligible = defaults.object(forKey: earliestEligibleKey) as? Date, eligible > now {{
-            if let deadline = defaults.object(forKey: deadlineKey) as? Date {{ return deadline <= now }}
-            return false
-        }}
-        return true
-    }}
-
-    private static func beginRun(source: String) -> UUID? {{
-        lock.lock()
-        defer {{ lock.unlock() }}
-        if defaults.string(forKey: activeRunKey) != nil {{ return nil }}
-        if let last = defaults.object(forKey: lastAttemptKey) as? Date,
-           Date().timeIntervalSince(last) < coalescingWindow {{ return nil }}
-        let runID = UUID()
-        defaults.set(runID.uuidString, forKey: activeRunKey)
-        defaults.set(Date(), forKey: lastAttemptKey)
-        defaults.set(Date(), forKey: lastTaskKey)
-        defaults.set("REFRESH_IN_PROGRESS", forKey: healthStateKey)
-        print("[LIVE_CONTAINER_REFRESH] RUN_BEGIN source=\\(source) run_id=\\(runID.uuidString)")
-        notify(title: "Refresh started", body: "Checking SideStore refresh requirements.", kind: "started")
-        return runID
-    }}
-
-    private static func endRun() {{
-        lock.lock()
-        defaults.removeObject(forKey: activeRunKey)
-        lock.unlock()
-    }}
-
-    private static func performRefresh(runID: UUID) async throws {{
-        print("[LIVE_CONTAINER_REFRESH] REFRESH_ATTEMPT_STARTED run_id=\\(runID.uuidString)")
-        defaults.set(runID.uuidString, forKey: expectedRunKey)
-        try await LiveContainerRefreshBridge.refreshAllApps()
-        print("[LIVE_CONTAINER_REFRESH] REFRESH_PIPELINE_RETURNED run_id=\\(runID.uuidString)")
-    }}
-
-    private static func verifyRefreshManifest() -> (verified: Bool, hostHandoff: Bool, reason: String) {{
-        guard let manifest = defaults.dictionary(forKey: verificationKey),
-              let results = manifest["results"] as? [[String: Any]], !results.isEmpty else {{
-            return (false, defaults.bool(forKey: hostHandoffKey), "verification_manifest_missing")
-        }}
-        guard manifest["run_id"] as? String == defaults.string(forKey: expectedRunKey) else {{
-            return (false, defaults.bool(forKey: hostHandoffKey), "verification_manifest_run_mismatch")
-        }}
-        let failures = results.filter {{ ($0["success"] as? Bool) != true }}
-        let hostHandoff = defaults.bool(forKey: hostHandoffKey)
-        if !failures.isEmpty {{ return (false, hostHandoff, "verification_manifest_contains_failure") }}
-        if hostHandoff {{ return (false, true, "host_handoff_awaiting_relaunch") }}
-        return (true, false, "verified_installed_app_records")
-    }}
-
-    private static func verifyPendingHostHandoff() {{
-        guard defaults.bool(forKey: hostHandoffKey) else {{ return }}
-        let previous = defaults.object(forKey: hostPreviousExpirationKey) as? Date
-        let manifest = defaults.dictionary(forKey: verificationKey)
-        guard manifest?["run_id"] as? String == defaults.string(forKey: hostHandoffRunKey) else {{
-            defaults.set("HOST_REFRESH_FAILED", forKey: healthStateKey)
-            defaults.set("verification_manifest_run_mismatch", forKey: lastErrorKey)
-            print("[LIVE_CONTAINER_REFRESH] HOST_REFRESH_FAILED reason=verification_manifest_run_mismatch")
-            return
-        }}
-        let results = manifest?["results"] as? [[String: Any]] ?? []
-        let hostResult = results.first {{ ($0["bundle_id"] as? String) == "com.kdt.livecontainer" }}
-        let expiration = hostResult?["expiration_date"] as? Date
-        if let previous, let expiration, expiration > previous {{
-            defaults.set(true, forKey: hostVerifiedKey)
-            defaults.set("HOST_REFRESH_VERIFIED", forKey: lastResultKey)
-            defaults.removeObject(forKey: hostHandoffKey)
-            print("[LIVE_CONTAINER_REFRESH] HOST_REFRESH_VERIFIED expiration_advanced=true")
-            cancelDeadlineAlarm()
-        }} else {{
-            defaults.set("HOST_REFRESH_FAILED", forKey: lastResultKey)
-            defaults.set("HOST_REFRESH_FAILED", forKey: healthStateKey)
-            defaults.set("expiration_not_verified", forKey: lastErrorKey)
-            print("[LIVE_CONTAINER_REFRESH] HOST_REFRESH_FAILED reason=expiration_not_verified")
-        }}
-    }}
-
-    private static func verifyGuestSignatures() -> Bool {{
-        let guests = DataManager.shared.model.apps + DataManager.shared.model.hiddenApps
-        var allValid = true
-        for guest in guests {{
-            guard let path = guest.appInfo.bundlePath(),
-                  let executable = Bundle(path: path)?.executableURL else {{
-                allValid = false
-                print("[LIVE_CONTAINER_REFRESH] GUEST_SIGNATURE_INVALID bundle_id=\\(guest.appInfo.bundleIdentifier()) reason=executable_missing")
-                continue
-            }}
-            let valid = executable.path.withCString {{ checkCodeSignature($0) }}
-            print("[LIVE_CONTAINER_REFRESH] GUEST_SIGNATURE_\\(valid ? \"VALID\" : \"INVALID\") bundle_id=\\(guest.appInfo.bundleIdentifier())")
-            if !valid {{ allValid = false }}
-        }}
-        return allValid
-    }}
-
-    private static func execute(source: String, task: BGTask? = nil) async {{
-        let started = Date()
-        let timeZone = TimeZone.autoupdatingCurrent
-        let deadline = defaults.object(forKey: deadlineKey) as? Date
-        let earliest = deadline?.addingTimeInterval(-leadTime)
-        print("[LIVE_CONTAINER_REFRESH] TASK_TRIGGERED source=\\(source) task_actual_start_local=\\(diagnosticDate(started, timeZone: timeZone)) task_actual_start_utc=\\(diagnosticDate(started, timeZone: TimeZone(secondsFromGMT: 0) ?? timeZone)) delay_from_earliest_begin=\\(earliest.map {{ String(format: \"%.0f\", started.timeIntervalSince($0)) }} ?? \"unknown\") timezone=\\(timeZone.identifier)")
-        guard compactWorkIsDue(now: started) else {{
-            print("[LIVE_CONTAINER_REFRESH] NO_OP source=\\(source)")
-            task?.setTaskCompleted(success: true)
-            return
-        }}
-        if source == "bgapprefresh" {{
-            print("[LIVE_CONTAINER_REFRESH] WATCHDOG_DUE action=resubmit_bgprocessing")
-            schedule()
-            task?.setTaskCompleted(success: true)
-            return
-        }}
-        guard let runID = beginRun(source: source) else {{
-            print("[LIVE_CONTAINER_REFRESH] RUN_COALESCED source=\\(source)")
-            task?.setTaskCompleted(success: true)
-            return
-        }}
-        defer {{ endRun() }}
-        do {{
-            try await performRefresh(runID: runID)
-            let verification = verifyRefreshManifest()
-            if verification.hostHandoff {{
-                defaults.set("HOST_REFRESH_AWAITING_RELAUNCH", forKey: healthStateKey)
-                record(source: source, result: "host_handoff_awaiting_relaunch", detail: verification.reason)
-                print("[LIVE_CONTAINER_REFRESH] HOST_REFRESH_AWAITING_RELAUNCH run_id=\\(runID.uuidString)")
-                notify(title: "Host refresh awaiting verification", body: "LiveContainer will verify the replacement after relaunch.", kind: "host_handoff")
-                task?.setTaskCompleted(success: true)
-            }} else if verification.verified && verifyGuestSignatures() {{
-                defaults.set(Date().addingTimeInterval(6 * 60 * 60), forKey: earliestEligibleKey)
-                defaults.removeObject(forKey: nextRetryKey)
-                defaults.set(0, forKey: retryCountKey)
-                defaults.set("REFRESH_SUCCEEDED", forKey: healthStateKey)
-                defaults.set(Date(), forKey: lastSuccessfulKey)
-                defaults.removeObject(forKey: lastErrorKey)
-                record(source: source, result: "verified", detail: verification.reason)
-                print("[LIVE_CONTAINER_REFRESH] REFRESH_RESULT run_id=\\(runID.uuidString) success=true verified=true")
-                notify(title: "Refresh completed", body: "Installed app records were verified.", kind: "verified")
-                cancelDeadlineAlarm()
-                task?.setTaskCompleted(success: true)
-            }} else if verification.verified {{
-                defaults.set("GUEST_SIGNATURE_INVALID", forKey: healthStateKey)
-                defaults.set("guest_signature_invalid", forKey: lastErrorKey)
-                record(source: source, result: "guest_signature_invalid", detail: "A LiveContainer guest signature could not be validated.")
-                notify(title: "Guest signature needs attention", body: "A LiveContainer guest could not be verified.", kind: "guest_invalid")
-                task?.setTaskCompleted(success: false)
-            }} else {{
-                throw NSError(domain: "LiveContainerRefresh", code: 1001,
-                    userInfo: [NSLocalizedDescriptionKey: verification.reason])
-            }}
-        }} catch {{
-            let count = defaults.integer(forKey: retryCountKey) + 1
-            defaults.set(count, forKey: retryCountKey)
-            let delays: [TimeInterval] = [5 * 60, 20 * 60, 60 * 60]
-            if count <= delays.count {{ defaults.set(Date().addingTimeInterval(delays[count - 1]), forKey: nextRetryKey) }}
-            defaults.set("REFRESH_FAILED", forKey: healthStateKey)
-            defaults.set(error.localizedDescription, forKey: lastErrorKey)
-            record(source: source, result: "failure", detail: error.localizedDescription)
-            print("[LIVE_CONTAINER_REFRESH] REFRESH_RESULT run_id=\\(runID.uuidString) success=false verified=false error_code=\\((error as NSError).code) error_domain=\\((error as NSError).domain) stage=refresh error=\\(error.localizedDescription)")
-            notify(title: "Refresh failed", body: error.localizedDescription, kind: "failed")
-            task?.setTaskCompleted(success: false)
-        }}
-    }}
-
-    static func register() {{
-        BGTaskScheduler.shared.register(forTaskWithIdentifier: taskIdentifier, using: nil) {{ task in
-            guard let task = task as? BGProcessingTask else {{ return }}
-            let operation = Task {{ await execute(source: "bgprocessing", task: task) }}
-            task.expirationHandler = {{
-                operation.cancel()
-                record(source: "bgprocessing", result: "expired", detail: "BGTask expiration")
-                print("[LIVE_CONTAINER_REFRESH] TASK_EXPIRED")
-                task.setTaskCompleted(success: false)
-            }}
-        }}
-        if #available(iOS 13.0, *) {{
-            BGTaskScheduler.shared.register(forTaskWithIdentifier: watchdogIdentifier, using: nil) {{ task in
-                guard let task = task as? BGAppRefreshTask else {{ return }}
-                let operation = Task {{ await execute(source: "bgapprefresh", task: task) }}
-                task.expirationHandler = {{ operation.cancel(); task.setTaskCompleted(success: false) }}
-            }}
-        }}
-        print("{MARKER}")
-    }}
-
-    static func requestRefreshNow() {{
-        Task {{ await execute(source: "alarm_action") }}
-    }}
-
-    static func runNow() {{
-        Task {{ await execute(source: "manual") }}
-    }}
-
-    static func recoverAfterLaunchOrResume() {{
-        verifyPendingHostHandoff()
-        guard defaults.object(forKey: earliestEligibleKey) != nil,
-              compactWorkIsDue(now: Date()) else {{ return }}
-        print("[LIVE_CONTAINER_REFRESH] RECOVERY_DUE source=launch_or_resume")
-        Task {{ await execute(source: "launch_or_resume") }}
-    }}
-
-    static func schedule() {{
-        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: taskIdentifier)
-        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: watchdogIdentifier)
-        guard defaults.bool(forKey: enabledKey) else {{
-            print("[LIVE_CONTAINER_REFRESH] SCHEDULE_DISABLED")
-            return
-        }}
-        let now = Date()
-        let deadline: Date
-        if let saved = defaults.object(forKey: deadlineKey) as? Date, saved > now {{
-            deadline = saved
-        }} else {{
-            deadline = nextDate(after: now)
-        }}
-        defaults.set(deadline, forKey: deadlineKey)
-        defaults.set("native_without_alarmkit", forKey: strategyKey)
-        let earliest = max(now, deadline.addingTimeInterval(-leadTime))
-        let request = BGProcessingTaskRequest(identifier: taskIdentifier)
-        request.requiresNetworkConnectivity = true
-        request.requiresExternalPower = false
-        request.earliestBeginDate = earliest
-        do {{
-            try BGTaskScheduler.shared.submit(request)
-            print("[LIVE_CONTAINER_REFRESH] SCHEDULE_PASS target_deadline=\\(deadline.timeIntervalSince1970) earliest_begin=\\(earliest.timeIntervalSince1970)")
-        }} catch {{
-            record(source: "scheduler", result: "bgprocessing_submit_failed", detail: error.localizedDescription)
-            print("[LIVE_CONTAINER_REFRESH] SCHEDULE_FAIL mechanism=bgprocessing error_code=\\((error as NSError).code) error_domain=\\((error as NSError).domain) error=\\(error.localizedDescription)")
-        }}
-        let watchdog = BGAppRefreshTaskRequest(identifier: watchdogIdentifier)
-        watchdog.earliestBeginDate = deadline
-        do {{
-            try BGTaskScheduler.shared.submit(watchdog)
-            print("[LIVE_CONTAINER_REFRESH] WATCHDOG_SCHEDULE_PASS target_deadline=\\(deadline.timeIntervalSince1970)")
-        }} catch {{
-            record(source: "scheduler", result: "bgapprefresh_submit_failed", detail: error.localizedDescription)
-            print("[LIVE_CONTAINER_REFRESH] WATCHDOG_SCHEDULE_FAIL error_code=\\((error as NSError).code) error_domain=\\((error as NSError).domain) error=\\(error.localizedDescription)")
-        }}
-        if #available(iOS 26.1, *) {{
-            Task {{ await LiveContainerAutoRefreshAlarmProvider.scheduleIfAvailable(deadline: deadline) }}
-        }} else {{
-            defaults.set("legacy_background", forKey: strategyKey)
-            print("[LIVE_CONTAINER_REFRESH] STRATEGY_SELECTED value=legacy_background")
-        }}
-    }}
-
-    private static func nextDate(after now: Date) -> Date {{
-        let frequency = defaults.string(forKey: frequencyKey) ?? "interval"
-        if frequency == "interval" {{ return now.addingTimeInterval(6 * 60 * 60) }}
-        let minutes = max(0, min(1439, defaults.object(forKey: minutesKey) as? Int ?? 600))
-        var components = DateComponents(hour: minutes / 60, minute: minutes % 60, second: 0)
-        if frequency == "weekly" {{ components.weekday = max(1, min(7, defaults.object(forKey: weekdayKey) as? Int ?? 2)) }}
-        return Calendar.autoupdatingCurrent.nextDate(after: now, matching: components,
-            matchingPolicy: .nextTime, repeatedTimePolicy: .first) ?? now.addingTimeInterval(6 * 60 * 60)
-    }}
-}}
-'''
-
-
-ALARM_PROVIDER = r'''
-#if canImport(AlarmKit)
-import AlarmKit
-import AppIntents
-import SwiftUI
-
-@available(iOS 26.1, *)
-private struct LiveContainerRefreshAlarmMetadata: AlarmMetadata {}
-
-@available(iOS 26.1, *)
-private struct LiveContainerRefreshAlarmIntent: LiveActivityIntent {
-    static var title: LocalizedStringResource { "Refresh LiveContainer now" }
-
-    func perform() async throws -> some IntentResult {
-        LiveContainerAutoRefreshScheduler.requestRefreshNow()
-        return .result()
-    }
-}
-
-@available(iOS 26.1, *)
-enum LiveContainerAutoRefreshAlarmProvider {
-    private static let alarmID = UUID(uuidString: "7B0A0E8E-0C90-4E33-9BA9-6DD38D8D5E2E")!
-
-    static func scheduleIfAvailable(deadline: Date) async {
-        guard AlarmManager.shared.authorizationState == .authorized else {
-            LiveContainerAutoRefreshScheduler.defaults.set("native_without_alarmkit", forKey: "liveContainerAutoRefreshStrategy")
-            LiveContainerAutoRefreshScheduler.defaults.set(false, forKey: "liveContainerAutoRefreshAlarmScheduled")
-            print("[LIVE_CONTAINER_REFRESH] ALARM_UNAVAILABLE reason=not_authorized")
-            return
-        }
-        if LiveContainerAutoRefreshScheduler.defaults.bool(forKey: "liveContainerAutoRefreshAlarmScheduled"),
-           let existing = LiveContainerAutoRefreshScheduler.defaults.object(forKey: "liveContainerAutoRefreshAlarmDeadline") as? Date,
-           abs(existing.timeIntervalSince(deadline)) < 1 {
-            return
-        }
-        let alert = AlarmPresentation.Alert(
-            title: "Automatic refresh deadline",
-            secondaryButton: AlarmButton(text: "Refresh Now", textColor: .white, systemImageName: "arrow.clockwise"),
-            secondaryButtonBehavior: .custom
-        )
-        let attributes: AlarmAttributes<LiveContainerRefreshAlarmMetadata> = AlarmAttributes(
-            presentation: AlarmPresentation(alert: alert),
-            metadata: LiveContainerRefreshAlarmMetadata(),
-            tintColor: Color.orange
-        )
-        let configuration: AlarmManager.AlarmConfiguration<LiveContainerRefreshAlarmMetadata> = AlarmManager.AlarmConfiguration.alarm(
-            schedule: .fixed(deadline),
-            attributes: attributes,
-            stopIntent: nil,
-            secondaryIntent: LiveContainerRefreshAlarmIntent(),
-            sound: .default
-        )
-        do {
-            _ = try await AlarmManager.shared.schedule(id: alarmID, configuration: configuration)
-            LiveContainerAutoRefreshScheduler.defaults.set(alarmID.uuidString, forKey: "liveContainerAutoRefreshAlarmID")
-            LiveContainerAutoRefreshScheduler.defaults.set(deadline, forKey: "liveContainerAutoRefreshAlarmDeadline")
-            LiveContainerAutoRefreshScheduler.defaults.set("native_full", forKey: "liveContainerAutoRefreshStrategy")
-            LiveContainerAutoRefreshScheduler.defaults.set(true, forKey: "liveContainerAutoRefreshAlarmScheduled")
-            print("[LIVE_CONTAINER_REFRESH] STRATEGY_SELECTED value=native_full")
-            print("[LIVE_CONTAINER_REFRESH] ALARM_SCHEDULE_PASS")
-        } catch {
-            print("[LIVE_CONTAINER_REFRESH] ALARM_SCHEDULE_FAIL error_code=\((error as NSError).code) error_domain=\((error as NSError).domain) error=\(error.localizedDescription)")
-        }
-    }
-
-    static func cancelIfAvailable() {
-        try? AlarmManager.shared.cancel(id: alarmID)
-        LiveContainerAutoRefreshScheduler.defaults.removeObject(forKey: "liveContainerAutoRefreshAlarmDeadline")
-    }
-}
-#else
-enum LiveContainerAutoRefreshAlarmProvider {
-    static func scheduleIfAvailable(deadline: Date) async {}
-    static func cancelIfAvailable() {}
-}
-#endif
-'''
-
-
-SETTINGS_VIEW = r'''
-import SwiftUI
-
-struct LCEmbeddedSideStoreRefreshView: View {
-    private let defaults = UserDefaults(suiteName: "group.com.SideStore.SideStore") ?? .standard
-    @State private var history: [[String: String]] = []
-    @AppStorage("liveContainerAutoRefreshEnabled", store: UserDefaults(suiteName: "group.com.SideStore.SideStore")) private var enabled = false
-    @AppStorage("liveContainerAutoRefreshFrequency", store: UserDefaults(suiteName: "group.com.SideStore.SideStore")) private var frequency = "interval"
-    @AppStorage("liveContainerAutoRefreshWeekday", store: UserDefaults(suiteName: "group.com.SideStore.SideStore")) private var weekday = 2
-    @AppStorage("liveContainerAutoRefreshMinutes", store: UserDefaults(suiteName: "group.com.SideStore.SideStore")) private var minutes = 600
-
-    private var time: Binding<Date> {
-        Binding(get: {
-            let calendar = Calendar.autoupdatingCurrent
-            return calendar.date(bySettingHour: minutes / 60, minute: minutes % 60, second: 0, of: Date()) ?? Date()
-        }, set: { value in
-            let parts = Calendar.autoupdatingCurrent.dateComponents([.hour, .minute], from: value)
-            minutes = (parts.hour ?? 10) * 60 + (parts.minute ?? 0)
-            notifyScheduleChanged()
-        })
-    }
-
-    var body: some View {
-        Form {
-            Section("Status") {
-                Text("Auto Refresh: \(enabled ? "Active" : "Inactive")")
-                let strategy = defaults.string(forKey: "liveContainerAutoRefreshStrategy") ?? "legacy_background"
-                let protection = strategy == "native_full" ? "Enhanced" : (strategy == "legacy_background" ? "Limited" : "Standard")
-                Text("Protection: \(protection)")
-                if protection == "Enhanced" {
-                    Text("Automatic background refresh + deadline protection")
-                        .font(.caption).foregroundColor(.secondary)
-                } else if protection == "Standard" {
-                    Text("Automatic background refresh is active. Exact deadline alerts are unavailable.")
-                        .font(.caption).foregroundColor(.secondary)
-                } else {
-                    Text("Refresh will be attempted whenever LiveContainer becomes active.")
-                        .font(.caption).foregroundColor(.secondary)
-                }
-            }
-            Section {
-                Toggle("Scheduled refresh", isOn: Binding(get: { enabled }, set: {
-                    enabled = $0
-                    notifyScheduleChanged()
-                }))
-                Button("Refresh SideStore now", action: notifyManualRefresh)
-                Picker("Frequency", selection: Binding(get: { frequency }, set: {
-                    frequency = $0
-                    notifyScheduleChanged()
-                })) {
-                    Text("Every six hours").tag("interval")
-                    Text("Daily").tag("daily")
-                    Text("Weekly").tag("weekly")
-                }.disabled(!enabled)
-                if frequency == "weekly" {
-                    Picker("Weekday", selection: Binding(get: { weekday }, set: {
-                        weekday = $0
-                        notifyScheduleChanged()
-                    })) {
-                        ForEach(1...7, id: \.self) { day in
-                            Text(Calendar.autoupdatingCurrent.weekdaySymbols[day - 1]).tag(day)
-                        }
-                    }.disabled(!enabled)
-                }
-                if frequency != "interval" {
-                    DatePicker("Preferred time (local)", selection: time, displayedComponents: .hourAndMinute)
-                        .disabled(!enabled)
-                }
-                Text("The host app owns this schedule. iOS may start it later than the requested time.")
-                    .font(.caption).foregroundColor(.secondary)
-            }
-            if let result = defaults.string(forKey: "liveContainerAutoRefreshLastResult") {
-                Section("Last result") {
-                    Text(result.capitalized)
-                    if let date = defaults.object(forKey: "liveContainerAutoRefreshLastDate") as? Date {
-                        Text(date.formatted(date: .abbreviated, time: .shortened)).font(.caption).foregroundColor(.secondary)
-                    }
-                }
-            }
-            Section("History") {
-                if history.isEmpty {
-                    Text("No refreshes recorded")
-                        .foregroundColor(.secondary)
-                } else {
-                    ForEach(Array(history.prefix(20).enumerated()), id: \.offset) { _, entry in
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("\(entry["source"]?.capitalized ?? "Unknown") - \(entry["result"]?.capitalized ?? "Unknown")")
-                            Text(entry["date"] ?? "")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                            if let detail = entry["detail"], !detail.isEmpty {
-                                Text(detail).font(.caption2).foregroundColor(.secondary)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        .navigationTitle("SideStore refresh")
-        .onAppear { reloadHistory() }
-        .onReceive(NotificationCenter.default.publisher(for: Notification.Name("LiveContainerAutoRefreshHistoryChanged"))) { _ in
-            reloadHistory()
-        }
-    }
-
-    private func notifyScheduleChanged() {
-        NotificationCenter.default.post(name: Notification.Name("LiveContainerAutoRefreshScheduleChanged"), object: nil)
-    }
-
-    private func notifyManualRefresh() {
-        LiveContainerAutoRefreshScheduler.requestNotificationPermission()
-        NotificationCenter.default.post(name: Notification.Name("LiveContainerAutoRefreshRunNow"), object: nil)
-    }
-
-    private func reloadHistory() {
-        history = defaults.array(forKey: "liveContainerAutoRefreshHistory") as? [[String: String]] ?? []
-    }
-}
-'''
-
-
 def patch_support(root: Path) -> None:
-    path = root / "SideStoreSupport" / "SideStore.swift"
+    path = root / "SideStoreSupport/SideStore.swift"
     text = path.read_text(encoding="utf-8")
-    if "LiveContainerRefreshBridge" not in text:
-        text = replace_once(text, "\nclass RefreshHandler: NSObject, RefreshServer {", BRIDGE + "\nclass RefreshHandler: NSObject, RefreshServer {", "refresh bridge insertion")
-        path.write_text(text, encoding="utf-8")
+    if "LC_REFRESH_BRIDGE_V2_BEGIN" in text:
+        if BRIDGE.strip() not in text:
+            die("outdated bridge template: reapply to the pinned clean source")
+        return
+    if "public enum LiveContainerRefreshBridge" in text:
+        die("legacy bridge already patched: reapply to the pinned clean source")
+    text = replace_once(text, "\nclass RefreshHandler: NSObject, RefreshServer {",
+                        BRIDGE + "\nclass RefreshHandler: NSObject, RefreshServer {", "refresh bridge insertion")
+    # Existing upstream guards must not silently return apparent success.
+    replacements = (
+        ("guard let listener = startAnonymousListener(self) else {\n                return\n            }",
+         "guard let listener = startAnonymousListener(self) else {\n                throw NSError(domain: \"LiveContainerRefresh.XPC\", code: 1, userInfo: [NSLocalizedDescriptionKey: \"Unable to create the embedded SideStore XPC listener.\"])\n            }"),
+        ("guard let listener = self.listener else {\n            return\n        }",
+         "guard let listener = self.listener else {\n            throw NSError(domain: \"LiveContainerRefresh.XPC\", code: 2, userInfo: [NSLocalizedDescriptionKey: \"Embedded SideStore XPC listener is unavailable.\"])\n        }"),
+        ("guard let ext else {\n                return\n            }",
+         "guard let ext else {\n                throw NSError(domain: \"LiveContainerRefresh.XPC\", code: 3, userInfo: [NSLocalizedDescriptionKey: \"LiveProcess could not be created.\"])\n            }"),
+    )
+    for old, new in replacements:
+        # Minimal unit fixtures contain no upstream implementation. A real
+        # pinned source must contain these guards and is covered by CI fixtures.
+        if old in text:
+            text = replace_once(text, old, new, "explicit XPC failure")
+    old = '''        self.client?.refreshAllApps(withIdentifier: identifier, mangledTypeName: mangledName)
+        
+        try await withUnsafeThrowingContinuation { c in
+            self.c = c
+        }'''
+    new = '''        guard let client = self.client else {
+            throw NSError(domain: "LiveContainerRefresh.XPC", code: 4,
+                userInfo: [NSLocalizedDescriptionKey: "Embedded SideStore did not establish its refresh connection."])
+        }
+        try await withUnsafeThrowingContinuation { c in
+            self.c = c
+            // Store the continuation BEFORE sending work to the remote process.
+            client.refreshAllApps(withIdentifier: identifier, mangledTypeName: mangledName)
+        }'''
+    if "self.client?.refreshAllApps(" in text:
+        text = replace_once(text, old, new, "XPC continuation-before-dispatch")
+    path.write_text(text, encoding="utf-8")
 
 
 def patch_host_delegate(root: Path) -> None:
-    path = root / "LiveContainerSwiftUI" / "App" / "AppDelegate.swift"
+    path = root / "LiveContainerSwiftUI/App/AppDelegate.swift"
     text = path.read_text(encoding="utf-8")
-    if "import BackgroundTasks" not in text:
-        text = replace_once(text, "import Intents\n", "import Intents\nimport BackgroundTasks\nimport SideStoreSupport\n", "host imports")
-    if "import UserNotifications" not in text:
-        text = replace_once(text, "import BackgroundTasks\n", "import BackgroundTasks\nimport UserNotifications\n", "host notification import")
-    if "LiveContainerAutoRefreshScheduler.register()" not in text:
-        text = replace_once(text, "        application.shortcutItems = nil\n", "        application.shortcutItems = nil\n        LiveContainerAutoRefreshScheduler.register()\n        LiveContainerAutoRefreshScheduler.schedule()\n        LiveContainerAutoRefreshScheduler.recoverAfterLaunchOrResume()\n        NotificationCenter.default.addObserver(forName: Notification.Name(\"LiveContainerAutoRefreshScheduleChanged\"), object: nil, queue: .main) { _ in\n            LiveContainerAutoRefreshScheduler.schedule()\n        }\n        NotificationCenter.default.addObserver(forName: Notification.Name(\"LiveContainerAutoRefreshRunNow\"), object: nil, queue: .main) { _ in\n            LiveContainerAutoRefreshScheduler.runNow()\n        }\n", "host scheduler startup")
-        text = replace_once(text, "    func application(_ application: UIApplication, configurationForConnecting", "    func applicationDidEnterBackground(_ application: UIApplication) {\n        LiveContainerAutoRefreshScheduler.schedule()\n    }\n\n    func applicationWillEnterForeground(_ application: UIApplication) {\n        LiveContainerAutoRefreshScheduler.recoverAfterLaunchOrResume()\n    }\n\n    func application(_ application: UIApplication, configurationForConnecting", "host background reschedule")
-        text = replace_once(text, "class SceneDelegate:", HOST_SCHEDULER + "\nclass SceneDelegate:", "host scheduler implementation")
-    if "UNUserNotificationCenter.current().delegate = self" not in text:
-        text = replace_once(text, "        application.shortcutItems = nil\n", "        application.shortcutItems = nil\n        UNUserNotificationCenter.current().delegate = self\n", "notification delegate setup")
-    if "extension AppDelegate: UNUserNotificationCenterDelegate" not in text:
-        text += "\n\n// Allows refresh status notifications while LiveContainer is foregrounded.\nextension AppDelegate: UNUserNotificationCenterDelegate {\n    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {\n        completionHandler([.banner, .sound])\n    }\n}\n"
+    if "// LC_REFRESH_HOST_V2" in text:
+        if HOST_SCHEDULER not in text:
+            die("outdated host template: reapply to the pinned clean source")
+        return
+    if "enum LiveContainerAutoRefreshScheduler" in text:
+        die("legacy scheduler already patched: reapply to the pinned clean source")
+    text = replace_once(text, "import Intents\n",
+                        "import Intents\nimport Foundation\nimport BackgroundTasks\nimport SideStoreSupport\nimport UserNotifications\n", "host imports")
+    startup = '''        application.shortcutItems = nil
+        // LC_REFRESH_HOST_V2
+        UNUserNotificationCenter.current().delegate = self
+        LiveContainerAutoRefreshScheduler.register()
+        LiveContainerAutoRefreshScheduler.recoverAfterLaunchOrResume()
+        LiveContainerAutoRefreshScheduler.schedule()
+        NotificationCenter.default.addObserver(forName: Notification.Name("LiveContainerAutoRefreshScheduleChanged"), object: nil, queue: .main) { _ in
+            Task { @MainActor in LiveContainerAutoRefreshScheduler.scheduleChanged() }
+        }
+        NotificationCenter.default.addObserver(forName: Notification.Name("LiveContainerAutoRefreshRunNow"), object: nil, queue: .main) { _ in
+            Task { @MainActor in LiveContainerAutoRefreshScheduler.runNow() }
+        }
+        NotificationCenter.default.addObserver(forName: UIScene.didActivateNotification, object: nil, queue: .main) { _ in
+            Task { @MainActor in LiveContainerAutoRefreshScheduler.recoverAfterLaunchOrResume() }
+        }
+        NotificationCenter.default.addObserver(forName: UIScene.didEnterBackgroundNotification, object: nil, queue: .main) { _ in
+            Task { @MainActor in LiveContainerAutoRefreshScheduler.schedule() }
+        }
+'''
+    text = replace_once(text, "        application.shortcutItems = nil\n", startup, "host scheduler startup")
+    text = replace_once(text, "class SceneDelegate:", HOST_SCHEDULER + "\nclass SceneDelegate:", "host scheduler implementation")
+    text += '''
+// Existing embedded notification handling remains in SideStoreSupport.
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.banner, .sound])
+    }
+}
+'''
     path.write_text(text, encoding="utf-8")
 
 
 def patch_host_info(root: Path) -> None:
-    path = root / "LiveContainer" / "Info.plist"
-    text = path.read_text(encoding="utf-8")
-    key = "<key>BGTaskSchedulerPermittedIdentifiers</key>"
-    if TASK_ID not in text or f"{TASK_ID}.watchdog" not in text:
-        insertion = f"\t{key}\n\t<array>\n\t\t<string>{TASK_ID}</string>\n\t\t<string>{TASK_ID}.watchdog</string>\n\t</array>\n"
-        closing = "</dict>\n</plist>"
-        if key in text:
-            start = text.index(key)
-            end = text.index("</array>", start) + len("</array>\n")
-            text = text[:start] + insertion + text[end:]
-        else:
-            text = replace_once(text, closing, insertion + closing, "host background task plist insertion")
-    if "<string>processing</string>" not in text:
-        if "\t<key>UIBackgroundModes</key>\n\t<array>\n" in text:
-            text = replace_once(
-                text,
-                "\t<key>UIBackgroundModes</key>\n\t<array>\n",
-                "\t<key>UIBackgroundModes</key>\n\t<array>\n\t\t<string>processing</string>\n",
-                "host processing background mode",
-            )
-        else:
-            text = replace_once(text, "</dict>\n</plist>", "\t<key>UIBackgroundModes</key>\n\t<array>\n\t\t<string>processing</string>\n\t</array>\n</dict>\n</plist>", "host processing background mode insertion")
-    if "NSAlarmKitUsageDescription" not in text:
-        text = replace_once(
-            text,
-            "</dict>\n</plist>",
-            "\t<key>NSAlarmKitUsageDescription</key>\n\t<string>Protect automatic refresh deadlines.</string>\n</dict>\n</plist>",
-            "AlarmKit usage description",
-        )
-    path.write_text(text, encoding="utf-8")
+    path = root / "LiveContainer/Info.plist"
+    info = plistlib.loads(path.read_bytes())
+    identifiers = list(info.get("BGTaskSchedulerPermittedIdentifiers", []))
+    modes = list(info.get("UIBackgroundModes", []))
+    for identifier in (TASK_ID, TASK_ID + ".watchdog"):
+        if identifier not in identifiers:
+            identifiers.append(identifier)
+    for mode in ("processing", "fetch"):
+        if mode not in modes:
+            modes.append(mode)
+    info["BGTaskSchedulerPermittedIdentifiers"] = identifiers
+    info["UIBackgroundModes"] = modes
+    info["LCRefreshContractVersion"] = 2
+    info.setdefault("NSAlarmKitUsageDescription", "Warn when an automatic refresh deadline needs attention.")
+    path.write_bytes(plistlib.dumps(info, sort_keys=False))
 
 
 def patch_alarm_provider(root: Path) -> None:
-    path = root / "LiveContainerSwiftUI" / "App" / "LiveContainerAutoRefreshAlarm.swift"
-    if not path.exists():
-        path.write_text(ALARM_PROVIDER.lstrip(), encoding="utf-8")
+    (root / "LiveContainerSwiftUI/App/LiveContainerAutoRefreshAlarm.swift").write_text(ALARM_PROVIDER, encoding="utf-8")
 
 
 def patch_project(root: Path) -> None:
-    path = root / "LiveContainer.xcodeproj" / "project.pbxproj"
+    # Preserve the pinned project's target graph and deployment targets.
+    path = root / "LiveContainer.xcodeproj/project.pbxproj"
     text = path.read_text(encoding="utf-8")
     if "SideStoreSupport.framework in Frameworks" not in text:
         text = replace_once(text, "/* Begin PBXBuildFile section */\n", "/* Begin PBXBuildFile section */\n\tA17ECAFE2DCA000000000001 = {isa = PBXBuildFile; fileRef = 173545A82E2C7913001B3B4C /* SideStoreSupport.framework */; };\n\tA17ECAFE2DCA000000000002 = {isa = PBXBuildFile; fileRef = 173545A82E2C7913001B3B4C /* SideStoreSupport.framework */; };\n", "host framework link build file")
@@ -683,92 +177,55 @@ def patch_project(root: Path) -> None:
         text = replace_once(text, "17413FB22D9C0BAE00F3F928 /* Frameworks */ = {\n\t\t\tisa = PBXFrameworksBuildPhase;\n\t\t\tbuildActionMask = 2147483647;\n\t\t\tfiles = (\n", "17413FB22D9C0BAE00F3F928 /* Frameworks */ = {\n\t\t\tisa = PBXFrameworksBuildPhase;\n\t\t\tbuildActionMask = 2147483647;\n\t\t\tfiles = (\n\t\t\t\tA17ECAFE2DCA000000000002 /* SideStoreSupport.framework in Frameworks */,\n", "host SwiftUI framework link phase")
         text = replace_once(text, "/* Begin PBXTargetDependency section */\n", "/* Begin PBXTargetDependency section */\n\tA17ECAFE2DCA000000000003 = {isa = PBXTargetDependency; target = 173545A72E2C7913001B3B4C /* SideStoreSupport */; targetProxy = 173545AC2E2C7913001B3B4C /* PBXContainerItemProxy */; };\n", "host SwiftUI target dependency")
         text = replace_once(text, "\t\t\tdependencies = (\n\t\t\t);\n\t\t\tfileSystemSynchronizedGroups = (\n\t\t\t\t17413FB62D9C0BAE00F3F928 /* LiveContainerSwiftUI */", "\t\t\tdependencies = (\n\t\t\t\tA17ECAFE2DCA000000000003 /* PBXTargetDependency */,\n\t\t\t);\n\t\t\tfileSystemSynchronizedGroups = (\n\t\t\t\t17413FB62D9C0BAE00F3F928 /* LiveContainerSwiftUI */", "host SwiftUI target dependency list")
-        path.write_text(text, encoding="utf-8")
     if "-weak_framework" not in text:
-        release_flags = '''\t\t\t\tOTHER_LDFLAGS = (\n\t\t\t\t\t"-e",\n\t\t\t\t\t_LiveContainerMainC,\n\t\t\t\t);'''
-        weak_flags = '''\t\t\t\tOTHER_LDFLAGS = (\n\t\t\t\t\t"-e",\n\t\t\t\t\t_LiveContainerMainC,\n\t\t\t\t\t"-weak_framework",\n\t\t\t\t\tAlarmKit,\n\t\t\t\t);'''
-        if release_flags in text:
-            text = text.replace(release_flags, weak_flags, 1)
-            path.write_text(text, encoding="utf-8")
+        old = '\t\t\t\tOTHER_LDFLAGS = (\n\t\t\t\t\t"-e",\n\t\t\t\t\t_LiveContainerMainC,\n\t\t\t\t);'
+        new = '\t\t\t\tOTHER_LDFLAGS = (\n\t\t\t\t\t"-e",\n\t\t\t\t\t_LiveContainerMainC,\n\t\t\t\t\t"-weak_framework",\n\t\t\t\t\tAlarmKit,\n\t\t\t\t);'
+        if old not in text:
+            die("host AlarmKit weak-link anchor missing")
+        text = text.replace(old, new)
+    swiftui_flags = 'OTHER_LDFLAGS = "-Wl,-U,_OBJC_CLASS_$_RBSTarget";'
+    if swiftui_flags in text:
+        text = text.replace(swiftui_flags, 'OTHER_LDFLAGS = "-Wl,-U,_OBJC_CLASS_$_RBSTarget -weak_framework AlarmKit";')
+    path.write_text(text, encoding="utf-8")
 
 
 def patch_settings(root: Path) -> None:
-    settings = root / "LiveContainerSwiftUI" / "Views" / "Settings" / "LCSettingsView.swift"
-    text = settings.read_text(encoding="utf-8")
+    path = root / "LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift"
+    text = path.read_text(encoding="utf-8")
     link = '''                if store == .SideStore {
                     Section {
-                        NavigationLink {
-                            LCEmbeddedSideStoreRefreshView()
-                        } label: {
-                            Text("SideStore scheduled refresh")
-                        }
+                        NavigationLink { LCEmbeddedSideStoreRefreshView() } label: { Text("SideStore scheduled refresh") }
                     }
                 }
 '''
     if "LCEmbeddedSideStoreRefreshView" not in text:
         text = replace_once(text, "            Form {\n", "            Form {\n" + link, "host refresh settings link")
-        settings.write_text(text, encoding="utf-8")
-
-    view = root / "LiveContainerSwiftUI" / "Views" / "Settings" / "LCEmbeddedSideStoreRefreshView.swift"
-    if not view.exists():
-        view.write_text(SETTINGS_VIEW.lstrip(), encoding="utf-8")
+        path.write_text(text, encoding="utf-8")
+    (path.parent / "LCEmbeddedSideStoreRefreshView.swift").write_text(SETTINGS_VIEW, encoding="utf-8")
 
 
 def verify(root: Path) -> None:
-    delegate = (root / "LiveContainerSwiftUI" / "App" / "AppDelegate.swift").read_text(encoding="utf-8")
-    support = (root / "SideStoreSupport" / "SideStore.swift").read_text(encoding="utf-8")
-    settings = (root / "LiveContainerSwiftUI" / "Views" / "Settings" / "LCEmbeddedSideStoreRefreshView.swift").read_text(encoding="utf-8")
-    info = (root / "LiveContainer" / "Info.plist").read_text(encoding="utf-8")
-    project = (root / "LiveContainer.xcodeproj" / "project.pbxproj").read_text(encoding="utf-8")
-    alarm = (root / "LiveContainerSwiftUI/App/LiveContainerAutoRefreshAlarm.swift").read_text(encoding="utf-8")
-    required = [
-        (delegate, "BGTaskScheduler.shared.register", "host registration"),
-        (delegate, "LiveContainerRefreshBridge.refreshAllApps", "host refresh bridge"),
-        (delegate, "requiresNetworkConnectivity = true", "network requirement"),
-        (delegate, "REFRESH_RESULT run_id=", "refresh result diagnostics"),
-        (delegate, "SCHEDULE_PASS target_deadline=", "deadline scheduling"),
-        (delegate, "task.setTaskCompleted(success: false)", "expiration completion"),
-        (delegate, "result: \"expired\"", "expiration history"),
-        (delegate, "LiveContainerAutoRefreshScheduler.runNow()", "manual refresh dispatch"),
-        (delegate, "verifyRefreshManifest", "refresh verification"),
-        (delegate, "HOST_REFRESH_AWAITING_RELAUNCH", "host handoff state"),
-        (delegate, "recoverAfterLaunchOrResume", "launch resume recovery"),
-        (delegate, "verifyGuestSignatures", "guest signature verification"),
-        (delegate, "GUEST_SIGNATURE_INVALID", "guest failure state"),
-        (support, "public enum LiveContainerRefreshBridge", "public bridge"),
-        (support, "RefreshHandler.shared.startRefresh", "embedded SideStore refresh"),
-        (support, "16SideStoreSupport20RefreshAllAppsIntentV", "combined refresh intent type"),
-        (settings, "liveContainerAutoRefreshFrequency", "schedule persistence"),
-        (settings, "Refresh SideStore now", "manual refresh control"),
-        (settings, "LiveContainerAutoRefreshRunNow", "manual refresh notification"),
-        (delegate, "record(source: source", "coalesced history"),
-        (delegate, "liveContainerAutoRefreshHistory", "history persistence"),
-        (delegate, "RUN_BEGIN source=", "run diagnostics"),
-        (delegate, "requestNotificationPermission", "notification authorization"),
-        (delegate, "NOTIFICATION_PASS", "notification delivery diagnostics"),
-        (delegate, "Refresh started", "start notification"),
-        (delegate, "Refresh completed", "verified notification"),
-        (delegate, "Refresh failed", "failure notification"),
-        (delegate, "UNUserNotificationCenterDelegate", "foreground notification delegate"),
-        (info, TASK_ID, "permitted task identifier"),
-        (info, f"{TASK_ID}.watchdog", "permitted watchdog identifier"),
-        (project, "A17ECAFE2DCA000000000001", "host framework link"),
-        (project, "A17ECAFE2DCA000000000002", "host SwiftUI framework link"),
-        (project, "A17ECAFE2DCA000000000003", "host SwiftUI target dependency"),
-        (alarm, "#if canImport(AlarmKit)", "AlarmKit compile isolation"),
-        (alarm, "@available(iOS 26.1, *)", "AlarmKit availability isolation"),
-        (alarm, "secondaryIntent", "AlarmKit user action fallback"),
-        (project, "-weak_framework", "AlarmKit weak link"),
-        (info, "<string>processing</string>", "host processing mode"),
-        (info, "NSAlarmKitUsageDescription", "AlarmKit usage description"),
-    ]
-    missing = [label for content, needle, label in required if needle not in content]
-    if missing:
-        die("verification failed: " + ", ".join(missing))
-    if 'static let taskIdentifier = "\\(Bundle.main.bundleIdentifier' not in delegate:
-        die("verification failed: signed host task identifier")
-    if "mangledName: \"9SideStore20RefreshAllAppsIntentV\"" in support:
-        die("verification failed: obsolete standalone refresh intent type")
+    delegate = (root / "LiveContainerSwiftUI/App/AppDelegate.swift").read_text(encoding="utf-8")
+    support = (root / "SideStoreSupport/SideStore.swift").read_text(encoding="utf-8")
+    info = plistlib.loads((root / "LiveContainer/Info.plist").read_bytes())
+    for identifier in (TASK_ID, TASK_ID + ".watchdog"):
+        if identifier not in info.get("BGTaskSchedulerPermittedIdentifiers", []):
+            die(f"missing permitted task identifier: {identifier}")
+    if not {"processing", "fetch"}.issubset(info.get("UIBackgroundModes", [])):
+        die("both processing and fetch background modes are required")
+    for marker in (MARKER, "LiveContainerRefreshTaskIdentifiers.resolve", "LiveContainerRefreshCompletionGate",
+                   "verifyRefreshManifest", "HOST_REFRESH_VERIFIED", "MISSED_BACKGROUND_REFRESH", "UNUserNotificationCenterDelegate"):
+        if marker not in delegate:
+            die(f"generated host missing {marker}")
+    if BRIDGE.strip() not in support:
+        die("combined intent bridge does not match the packaged metadata contract")
+    if r'\\(' in HOST_SCHEDULER:
+        die("Swift interpolation was double-escaped in a plain Swift template")
+    compiler = shutil.which("swiftc")
+    if compiler:
+        for relative in ("LiveContainerSwiftUI/App/AppDelegate.swift", "LiveContainerSwiftUI/App/LiveContainerAutoRefreshAlarm.swift",
+                         "LiveContainerSwiftUI/Views/Settings/LCEmbeddedSideStoreRefreshView.swift", "SideStoreSupport/SideStore.swift"):
+            subprocess.run([compiler, "-frontend", "-parse", str(root / relative)], check=True)
 
 
 def main() -> None:

--- a/scripts/templates/livecontainer_refresh_alarm.swift
+++ b/scripts/templates/livecontainer_refresh_alarm.swift
@@ -1,0 +1,108 @@
+import Foundation
+import UserNotifications
+#if canImport(AlarmKit)
+import AlarmKit
+import AppIntents
+import SwiftUI
+
+@available(iOS 26.1, *)
+private struct LiveContainerRefreshAlarmMetadata: AlarmMetadata {}
+
+@available(iOS 26.1, *)
+private struct LiveContainerRefreshAlarmIntent: LiveActivityIntent {
+    static var title: LocalizedStringResource { "Refresh LiveContainer now" }
+    static var openAppWhenRun: Bool { true }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        // Await the operation; returning after spawning an unstructured Task
+        // would tell the intent system it can end our execution prematurely.
+        await LiveContainerAutoRefreshScheduler.requestRefreshNow()
+        return .result()
+    }
+}
+
+@available(iOS 26.1, *)
+@MainActor
+enum LiveContainerAutoRefreshAlarmProvider {
+    private static let alarmID = UUID(uuidString: "7B0A0E8E-0C90-4E33-9BA9-6DD38D8D5E2E")!
+
+    private static var scheduling = false
+
+    static func requestAuthorization() async {
+        do { _ = try await AlarmManager.shared.requestAuthorization() }
+        catch { print("[LIVE_CONTAINER_REFRESH] ALARM_AUTHORIZATION_FAIL error=\(error.localizedDescription)") }
+        LiveContainerAutoRefreshScheduler.schedule()
+    }
+
+    static func scheduleIfAvailable(deadline: Date) async {
+        let defaults = LiveContainerAutoRefreshScheduler.defaults
+        guard !scheduling else { return }
+        scheduling = true
+        defer { scheduling = false }
+        guard defaults.bool(forKey: LiveContainerAutoRefreshScheduler.enabledKey), deadline > Date(),
+              AlarmManager.shared.authorizationState == .authorized else {
+            defaults.set(false, forKey: "liveContainerAutoRefreshAlarmScheduled")
+            print("[LIVE_CONTAINER_REFRESH] ALARM_UNAVAILABLE reason=disabled_or_not_authorized")
+            return // The pre-scheduled local notification remains the fallback.
+        }
+        let liveAlarms = (try? AlarmManager.shared.alarms) ?? []
+        if liveAlarms.contains(where: { $0.id == alarmID }), defaults.bool(forKey: "liveContainerAutoRefreshAlarmScheduled"),
+           let existing = defaults.object(forKey: "liveContainerAutoRefreshAlarmDeadline") as? Date,
+           abs(existing.timeIntervalSince(deadline)) < 1 {
+            UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [LiveContainerAutoRefreshScheduler.warningIdentifier])
+            return
+        }
+        if liveAlarms.contains(where: { $0.id == alarmID }) {
+            do { try AlarmManager.shared.cancel(id: alarmID) }
+            catch { print("[LIVE_CONTAINER_REFRESH] ALARM_REPLACE_FAIL error=\(error.localizedDescription)"); return }
+        }
+        let alert = AlarmPresentation.Alert(
+            title: "Automatic refresh needs checking",
+            secondaryButton: AlarmButton(text: "Refresh Now", textColor: .white, systemImageName: "arrow.clockwise"),
+            secondaryButtonBehavior: .custom)
+        let attributes: AlarmAttributes<LiveContainerRefreshAlarmMetadata> = AlarmAttributes(
+            presentation: AlarmPresentation(alert: alert), metadata: LiveContainerRefreshAlarmMetadata(), tintColor: Color.orange)
+        let configuration: AlarmManager.AlarmConfiguration<LiveContainerRefreshAlarmMetadata> = AlarmManager.AlarmConfiguration.alarm(
+            schedule: .fixed(deadline), attributes: attributes, stopIntent: nil,
+            secondaryIntent: LiveContainerRefreshAlarmIntent(), sound: .default)
+        do {
+            _ = try await AlarmManager.shared.schedule(id: alarmID, configuration: configuration)
+            guard defaults.bool(forKey: LiveContainerAutoRefreshScheduler.enabledKey),
+                  (defaults.object(forKey: LiveContainerAutoRefreshScheduler.deadlineKey) as? Date) == deadline else {
+                cancelIfAvailable()
+                return
+            }
+            defaults.set(deadline, forKey: "liveContainerAutoRefreshAlarmDeadline")
+            defaults.set(alarmID.uuidString, forKey: "liveContainerAutoRefreshAlarmID")
+            defaults.set(true, forKey: "liveContainerAutoRefreshAlarmScheduled")
+            defaults.set("native_full", forKey: "liveContainerAutoRefreshStrategy")
+            UNUserNotificationCenter.current().removePendingNotificationRequests(
+                withIdentifiers: [LiveContainerAutoRefreshScheduler.warningIdentifier])
+            print("[LIVE_CONTAINER_REFRESH] ALARM_SCHEDULE_PASS")
+        } catch {
+            defaults.set(false, forKey: "liveContainerAutoRefreshAlarmScheduled")
+            print("[LIVE_CONTAINER_REFRESH] ALARM_SCHEDULE_FAIL error=\(error.localizedDescription)")
+            // Do not disable BG refresh or delete the local-notification fallback.
+        }
+    }
+
+    static func cancelIfAvailable() {
+        do { try AlarmManager.shared.cancel(id: alarmID) }
+        catch {
+            LiveContainerAutoRefreshScheduler.defaults.set(error.localizedDescription, forKey: "liveContainerAutoRefreshDeadlineWarningError")
+            print("[LIVE_CONTAINER_REFRESH] ALARM_CANCEL_RESULT error=\(error.localizedDescription)")
+            return
+        }
+        LiveContainerAutoRefreshScheduler.defaults.removeObject(forKey: "liveContainerAutoRefreshAlarmDeadline")
+        LiveContainerAutoRefreshScheduler.defaults.set(false, forKey: "liveContainerAutoRefreshAlarmScheduled")
+    }
+}
+#else
+@MainActor
+enum LiveContainerAutoRefreshAlarmProvider {
+    static func requestAuthorization() async {}
+    static func scheduleIfAvailable(deadline: Date) async {}
+    static func cancelIfAvailable() {}
+}
+#endif

--- a/scripts/templates/livecontainer_refresh_policy.swift
+++ b/scripts/templates/livecontainer_refresh_policy.swift
@@ -1,0 +1,106 @@
+// Foundation-only policy. Kept outside Python strings so swiftc checks the real code.
+import Foundation
+
+struct LiveContainerRefreshTaskIdentifiers: Equatable {
+    let processing: String
+    let watchdog: String
+
+    static func resolve(info: [String: Any]) throws -> Self {
+        let suffix = ".sidestore.automatic-refresh"
+        let permitted = info["BGTaskSchedulerPermittedIdentifiers"] as? [String] ?? []
+        let candidates = permitted.filter { $0.hasSuffix(suffix) }
+        guard candidates.count == 1, Set(permitted).count == permitted.count,
+              permitted.contains(candidates[0] + ".watchdog") else {
+            throw NSError(domain: "LiveContainerRefresh.Configuration", code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "This installation has missing or ambiguous background task identifiers. Reinstall a corrected build; manual refresh remains available."])
+        }
+        let modes = Set(info["UIBackgroundModes"] as? [String] ?? [])
+        guard modes.contains("processing"), modes.contains("fetch") else {
+            throw NSError(domain: "LiveContainerRefresh.Configuration", code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "This installation is missing the processing or fetch background mode. Manual refresh remains available."])
+        }
+        // The installed allowlist is authoritative. An external signer may leave
+        // these IDs unchanged OR rewrite them. Do not invent a team-qualified ID.
+        return Self(processing: candidates[0], watchdog: candidates[0] + ".watchdog")
+    }
+}
+
+struct LiveContainerRefreshPolicy {
+    static func earliestUsefulDate(now: Date, deadline: Date, lead: TimeInterval,
+                                   eligible: Date?, retry: Date?) -> Date {
+        [now, deadline.addingTimeInterval(-lead), eligible ?? now, retry ?? now].max()!
+    }
+
+    static func workIsDue(now: Date, eligible: Date?, retry: Date?, pendingHandoff: Bool,
+                          retryExhausted: Bool, manual: Bool) -> Bool {
+        if pendingHandoff { return false }
+        if manual { return true }
+        if retryExhausted { return false }
+        if let retry, retry > now { return false }
+        if let eligible, eligible > now { return false }
+        return true
+    }
+
+    static func retryDelay(failureCount: Int) -> TimeInterval? {
+        let delays: [TimeInterval] = [5 * 60, 20 * 60, 60 * 60]
+        guard (1...delays.count).contains(failureCount) else { return nil }
+        return delays[failureCount - 1]
+    }
+
+    static func isUserActionFailure(_ error: NSError) -> Bool {
+        // Classify by concrete domain/code, not by guessing from localized text.
+        error.domain == "LiveContainerRefresh.Configuration" ||
+        error.domain == "com.SideStore.Authentication" ||
+        error.domain == "LiveContainerRefresh.UnsupportedOS"
+    }
+}
+
+/// Thread-safe terminal claim shared by completion and expiration callbacks.
+/// A late async completion must not call setTaskCompleted for a second time.
+final class LiveContainerRefreshCompletionGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var finished = false
+
+    var isFinished: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return finished
+    }
+
+    @discardableResult
+    func claim() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !finished else { return false }
+        finished = true
+        return true
+    }
+}
+
+/// Reads validity metadata from the installed, OS-signed host bundle, never
+/// from SideStore's optimistic database result. This is metadata inspection,
+/// NOT independent cryptographic validation of the CMS signer/certificate.
+struct LiveContainerHostProfile {
+    let identifier: String
+    let uuid: String
+    let expiration: Date
+
+    static func read(at url: URL, expectedBundleID: String) throws -> Self {
+        let data = try Data(contentsOf: url, options: .mappedIfSafe)
+        guard data.count <= 2 * 1024 * 1024,
+              let start = data.range(of: Data("<?xml".utf8)),
+              let end = data.range(of: Data("</plist>".utf8), in: start.lowerBound..<data.endIndex),
+              let plist = try PropertyListSerialization.propertyList(
+                  from: data.subdata(in: start.lowerBound..<end.upperBound), options: [], format: nil) as? [String: Any],
+              let entitlements = plist["Entitlements"] as? [String: Any],
+              let identifier = entitlements["application-identifier"] as? String,
+              let prefixes = plist["ApplicationIdentifierPrefix"] as? [String],
+              prefixes.contains(where: { identifier == $0 + "." + expectedBundleID }),
+              let uuid = plist["UUID"] as? String, !uuid.isEmpty,
+              let expiration = plist["ExpirationDate"] as? Date else {
+            throw NSError(domain: "LiveContainerRefresh.Verification", code: 1002,
+                userInfo: [NSLocalizedDescriptionKey: "The installed host provisioning profile could not be read or its identity does not match. Refresh success has not been verified."])
+        }
+        return Self(identifier: identifier, uuid: uuid, expiration: expiration)
+    }
+}

--- a/scripts/templates/livecontainer_refresh_scheduler.swift
+++ b/scripts/templates/livecontainer_refresh_scheduler.swift
@@ -1,0 +1,501 @@
+// Injected into the LiveContainer host, not its embedded SideStore executable.
+// There is no timer, persistent network probe, or permanently running task.
+@MainActor
+enum LiveContainerAutoRefreshScheduler {
+    static let defaults = UserDefaults(suiteName: "group.com.SideStore.SideStore") ?? .standard
+    static let enabledKey = "liveContainerAutoRefreshEnabled"
+    static let frequencyKey = "liveContainerAutoRefreshFrequency"
+    static let weekdayKey = "liveContainerAutoRefreshWeekday"
+    static let minutesKey = "liveContainerAutoRefreshMinutes"
+    static let lastResultKey = "liveContainerAutoRefreshLastResult"
+    static let lastDateKey = "liveContainerAutoRefreshLastDate"
+    static let historyKey = "liveContainerAutoRefreshHistory"
+    static let earliestEligibleKey = "liveContainerAutoRefreshEarliestEligibleAt"
+    static let deadlineKey = "liveContainerAutoRefreshTargetDeadline"
+    static let nextRetryKey = "liveContainerAutoRefreshNextRetryAt"
+    static let lastTaskKey = "liveContainerAutoRefreshLastTaskTrigger"
+    static let lastAttemptKey = "liveContainerAutoRefreshLastAttempt"
+    static let activeRunKey = "liveContainerAutoRefreshActiveRunID"
+    static let retryCountKey = "liveContainerAutoRefreshRetryCount"
+    static let hostHandoffKey = "liveContainerAutoRefreshHostHandoff"
+    static let hostHandoffRunKey = "liveContainerAutoRefreshHostHandoffRunID"
+    static let hostHandoffStartedKey = "liveContainerAutoRefreshHostHandoffStartedAt"
+    static let hostPreviousExpirationKey = "liveContainerAutoRefreshHostPreviousExpiration"
+    static let verificationKey = "liveContainerAutoRefreshVerification"
+    static let expectedRunKey = "liveContainerAutoRefreshExpectedRunID"
+    static let hostVerifiedKey = "liveContainerAutoRefreshHostVerifiedAfterRelaunch"
+    static let strategyKey = "liveContainerAutoRefreshStrategy"
+    static let alarmScheduledKey = "liveContainerAutoRefreshAlarmScheduled"
+    static let alarmDeadlineKey = "liveContainerAutoRefreshAlarmDeadline"
+    static let healthStateKey = "liveContainerAutoRefreshHealthState"
+    static let lastErrorKey = "liveContainerAutoRefreshLastError"
+    static let lastSuccessfulKey = "liveContainerAutoRefreshLastSuccessfulRefresh"
+    static let hostBaselineKey = "liveContainerAutoRefreshInstalledHostBaseline"
+    static let satisfiedDeadlineKey = "liveContainerAutoRefreshSatisfiedDeadline"
+    static let warnedDeadlineKey = "liveContainerAutoRefreshWarnedDeadline"
+    static let configurationKey = "liveContainerAutoRefreshConfiguration"
+    static let retryExhaustedKey = "liveContainerAutoRefreshRetryExhausted"
+    static let warningIdentifier = "LiveContainerAutoRefresh.deadline"
+    static let leadTime: TimeInterval = 60 * 60 // Provisional policy, not a timing guarantee.
+    static let coalescingWindow: TimeInterval = 60
+
+    private static var identifiers: LiveContainerRefreshTaskIdentifiers?
+    private static var processingRegistered = false
+    private static var watchdogRegistered = false
+    private static var registered = false
+    private static var activeRun: UUID?
+    // Capture the real host before LiveContainer changes Bundle.main for guests.
+    private static var hostBundle: Bundle?
+
+    static func requestNotificationPermission() async {
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+        guard settings.authorizationStatus == .notDetermined else { return }
+        do {
+            let granted = try await center.requestAuthorization(options: [.alert, .sound])
+            print("[LIVE_CONTAINER_REFRESH] NOTIFICATION_PERMISSION granted=\(granted)")
+        } catch {
+            print("[LIVE_CONTAINER_REFRESH] NOTIFICATION_PERMISSION_FAIL error=\(error.localizedDescription)")
+        }
+    }
+
+    private static func notify(title: String, body: String, kind: String) {
+        let center = UNUserNotificationCenter.current()
+        center.getNotificationSettings { settings in
+            guard settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional else {
+                print("[LIVE_CONTAINER_REFRESH] NOTIFICATION_SKIPPED kind=\(kind) reason=not_authorized")
+                return
+            }
+            let content = UNMutableNotificationContent()
+            content.title = title
+            content.body = body
+            content.sound = .default
+            center.add(UNNotificationRequest(identifier: "LiveContainerAutoRefresh.\(kind)", content: content, trigger: nil)) { error in
+                if let error {
+                    print("[LIVE_CONTAINER_REFRESH] NOTIFICATION_FAIL kind=\(kind) error=\(error.localizedDescription)")
+                } else {
+                    // Accepted by notification service, not proof the user saw it.
+                    print("[LIVE_CONTAINER_REFRESH] NOTIFICATION_PASS kind=\(kind)")
+                }
+            }
+        }
+    }
+
+    private static func record(source: String, result: String, detail: String = "") {
+        let now = Date()
+        let entry = ["date": ISO8601DateFormatter().string(from: now), "source": source,
+                     "result": result, "detail": String(detail.prefix(300))]
+        var history = defaults.array(forKey: historyKey) as? [[String: String]] ?? []
+        history.insert(entry, at: 0)
+        defaults.set(Array(history.prefix(50)), forKey: historyKey)
+        defaults.set(result, forKey: lastResultKey)
+        defaults.set(now, forKey: lastDateKey)
+        NotificationCenter.default.post(name: Notification.Name("LiveContainerAutoRefreshHistoryChanged"), object: nil)
+    }
+
+    private static func compactWorkIsDue(now: Date, manual: Bool = false) -> Bool {
+        LiveContainerRefreshPolicy.workIsDue(now: now,
+            eligible: defaults.object(forKey: earliestEligibleKey) as? Date,
+            retry: defaults.object(forKey: nextRetryKey) as? Date,
+            pendingHandoff: defaults.bool(forKey: hostHandoffKey),
+            retryExhausted: defaults.bool(forKey: retryExhaustedKey), manual: manual)
+    }
+
+    private static func observeMissedDeadline(now: Date) {
+        guard defaults.bool(forKey: enabledKey),
+              let deadline = defaults.object(forKey: deadlineKey) as? Date, now > deadline,
+              (defaults.object(forKey: satisfiedDeadlineKey) as? Date) != deadline,
+              (defaults.object(forKey: warnedDeadlineKey) as? Date) != deadline else { return }
+        defaults.set(deadline, forKey: warnedDeadlineKey)
+        defaults.set("REFRESH_DEADLINE_MISSED", forKey: healthStateKey)
+        record(source: "watchdog", result: "missed_window", detail: "No verified refresh for the expected deadline. The task may have been delayed, failed, or never launched.")
+        print("[LIVE_CONTAINER_REFRESH] MISSED_BACKGROUND_REFRESH deadline=\(deadline.timeIntervalSince1970)")
+    }
+
+    private static func beginRun(source: String, manual: Bool) -> UUID? {
+        guard activeRun == nil else { return nil }
+        if !manual, let last = defaults.object(forKey: lastAttemptKey) as? Date,
+           Date().timeIntervalSince(last) < coalescingWindow { return nil }
+        let id = UUID()
+        activeRun = id
+        defaults.set(id.uuidString, forKey: activeRunKey)
+        defaults.set(id.uuidString, forKey: expectedRunKey)
+        defaults.set(Date(), forKey: lastAttemptKey)
+        defaults.removeObject(forKey: verificationKey)
+        defaults.set(false, forKey: hostVerifiedKey)
+        defaults.set("REFRESH_IN_PROGRESS", forKey: healthStateKey)
+        // Snapshot actual installed host metadata before the refresh engine can
+        // optimistically update its database. Absence never becomes success.
+        if let bundle = hostBundle, let bundleID = bundle.bundleIdentifier,
+           let profile = try? LiveContainerHostProfile.read(
+               at: bundle.bundleURL.appendingPathComponent("embedded.mobileprovision"), expectedBundleID: bundleID) {
+            defaults.set(["run_id": id.uuidString, "identifier": profile.identifier,
+                          "uuid": profile.uuid, "expiration": profile.expiration], forKey: hostBaselineKey)
+        } else {
+            defaults.removeObject(forKey: hostBaselineKey)
+        }
+        print("[LIVE_CONTAINER_REFRESH] RUN_BEGIN source=\(source) run_id=\(id.uuidString)")
+        notify(title: "Refresh started", body: "Checking SideStore refresh requirements. Success is not yet confirmed.", kind: "started")
+        return id
+    }
+
+    private static func endRun(_ id: UUID) {
+        guard activeRun == id else { return }
+        activeRun = nil
+        defaults.removeObject(forKey: activeRunKey)
+        if defaults.string(forKey: expectedRunKey) == id.uuidString {
+            defaults.removeObject(forKey: expectedRunKey)
+        }
+    }
+
+    private static func performRefresh(runID: UUID) async throws {
+        guard #available(iOS 17.0, *) else {
+            throw NSError(domain: "LiveContainerRefresh.UnsupportedOS", code: 17,
+                userInfo: [NSLocalizedDescriptionKey: "This automatic embedded bridge requires iOS 17 or later. Use the existing embedded SideStore manual refresh on this version."])
+        }
+        try Task.checkCancellation()
+        print("[LIVE_CONTAINER_REFRESH] REFRESH_ATTEMPT_STARTED run_id=\(runID.uuidString)")
+        try await LiveContainerRefreshBridge.refreshAllApps()
+        try Task.checkCancellation()
+        print("[LIVE_CONTAINER_REFRESH] REFRESH_PIPELINE_RETURNED run_id=\(runID.uuidString)")
+    }
+
+    private static func verifyRefreshManifest(runID: String) -> (verified: Bool, hostHandoff: Bool, reason: String) {
+        let pending = defaults.bool(forKey: hostHandoffKey)
+        guard let manifest = defaults.dictionary(forKey: verificationKey),
+              manifest["run_id"] as? String == runID,
+              let results = manifest["results"] as? [[String: Any]], !results.isEmpty else {
+            return (false, pending, "verification_manifest_missing_or_wrong_run")
+        }
+        guard let expected = manifest["expected_ids"] as? [String], !expected.isEmpty,
+              Set(results.compactMap { $0["bundle_id"] as? String }) == Set(expected) else {
+            return (false, pending, "verification_manifest_incomplete")
+        }
+        if results.contains(where: { ($0["success"] as? Bool) != true }) {
+            return (false, pending, "verification_manifest_contains_failure")
+        }
+        return pending ? (false, true, "host_handoff_awaiting_relaunch") : (true, false, "verified_installed_app_records")
+    }
+
+    private static func markVerified(source: String, detail: String) {
+        defaults.set(Date().addingTimeInterval(6 * 60 * 60), forKey: earliestEligibleKey)
+        defaults.removeObject(forKey: nextRetryKey)
+        defaults.set(0, forKey: retryCountKey)
+        defaults.set(false, forKey: retryExhaustedKey)
+        defaults.set("REFRESH_SUCCEEDED", forKey: healthStateKey)
+        defaults.set(Date(), forKey: lastSuccessfulKey)
+        defaults.removeObject(forKey: lastErrorKey)
+        if let deadline = defaults.object(forKey: deadlineKey) as? Date {
+            defaults.set(deadline, forKey: satisfiedDeadlineKey)
+        }
+        record(source: source, result: "verified", detail: detail)
+        cancelDeadlineProtection()
+        notify(title: "Refresh completed", body: detail, kind: "verified")
+    }
+
+    private static func verifyPendingHostHandoff() {
+        guard activeRun == nil, defaults.bool(forKey: hostHandoffKey) else { return }
+        guard let baseline = defaults.dictionary(forKey: hostBaselineKey),
+              let runID = baseline["run_id"] as? String,
+              runID == defaults.string(forKey: hostHandoffRunKey),
+              let previous = baseline["expiration"] as? Date,
+              let bundle = hostBundle, let bundleID = bundle.bundleIdentifier else {
+            defaults.set("HOST_REFRESH_UNVERIFIED", forKey: healthStateKey)
+            defaults.set("installed_host_baseline_unavailable", forKey: lastErrorKey)
+            defaults.removeObject(forKey: hostHandoffKey)
+            defaults.set(true, forKey: retryExhaustedKey)
+            record(source: "relaunch", result: "host_unverified", detail: "The old run has no installed-profile baseline. Its result is unknown; a new manual attempt can establish one.")
+            return
+        }
+        do {
+            let current = try LiveContainerHostProfile.read(
+                at: bundle.bundleURL.appendingPathComponent("embedded.mobileprovision"), expectedBundleID: bundleID)
+            guard current.expiration > previous, current.expiration > Date() else {
+                defaults.set("HOST_REFRESH_AWAITING_RELAUNCH", forKey: healthStateKey)
+                defaults.set("installed_host_expiration_not_advanced", forKey: lastErrorKey)
+                print("[LIVE_CONTAINER_REFRESH] HOST_REFRESH_UNVERIFIED reason=installed_profile_expiration_not_advanced")
+                if let started = defaults.object(forKey: hostHandoffStartedKey) as? Date,
+                   Date().timeIntervalSince(started) >= 180 {
+                    defaults.removeObject(forKey: hostHandoffKey)
+                    defaults.set(true, forKey: retryExhaustedKey)
+                    defaults.set("HOST_REFRESH_FAILED", forKey: healthStateKey)
+                    record(source: "relaunch", result: "host_refresh_failed", detail: "The installed host profile did not advance after replacement. Retry manually; no success was recorded.")
+                    notify(title: "LiveContainer refresh not confirmed", body: "Its installed signing validity did not advance. Open SideStore and retry the refresh.", kind: "host_failed")
+                }
+                return
+            }
+            defaults.set(true, forKey: hostVerifiedKey)
+            defaults.removeObject(forKey: hostHandoffKey)
+            print("[LIVE_CONTAINER_REFRESH] HOST_REFRESH_VERIFIED evidence=installed_profile_expiration_advanced")
+            let batch = verifyRefreshManifest(runID: runID)
+            if batch.verified {
+                markVerified(source: "relaunch", detail: "LiveContainer's installed profile renewed; all requested app results were confirmed.")
+            } else {
+                // Host replacement can kill the process before it writes the
+                // final batch results. Host success is not whole-batch success.
+                defaults.set("HOST_REFRESH_VERIFIED", forKey: healthStateKey)
+                record(source: "relaunch", result: "host_verified_batch_unconfirmed", detail: batch.reason)
+                notify(title: "LiveContainer refreshed", body: "Its installed profile renewed. Some batch results remain unconfirmed; check SideStore history.", kind: "host_verified")
+            }
+        } catch {
+            defaults.set("HOST_REFRESH_AWAITING_RELAUNCH", forKey: healthStateKey)
+            defaults.set(error.localizedDescription, forKey: lastErrorKey)
+            print("[LIVE_CONTAINER_REFRESH] HOST_REFRESH_UNVERIFIED error=\(error.localizedDescription)")
+        }
+    }
+
+    private static func verifyGuestSignatures() -> Bool {
+        // Guests are not standalone InstalledApps and are never re-signed here.
+        let guests = DataManager.shared.model.apps + DataManager.shared.model.hiddenApps
+        for guest in guests {
+            guard let path = guest.appInfo.bundlePath(), let executable = Bundle(path: path)?.executableURL,
+                  executable.path.withCString({ checkCodeSignature($0) }) else {
+                print("[LIVE_CONTAINER_REFRESH] GUEST_SIGNATURE_INVALID bundle_id=\(guest.appInfo.bundleIdentifier())")
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func execute(source: String, task: BGTask? = nil,
+                                gate: LiveContainerRefreshCompletionGate = LiveContainerRefreshCompletionGate()) async {
+        guard !gate.isFinished, !Task.isCancelled else { return }
+        let manual = source == "manual" || source == "alarm_action"
+        let now = Date()
+        print("[LIVE_CONTAINER_REFRESH] TASK_TRIGGERED source=\(source) at=\(now.timeIntervalSince1970)")
+        if source == "bgprocessing" || source == "bgapprefresh" { defaults.set(now, forKey: lastTaskKey) }
+        observeMissedDeadline(now: now)
+        func finish(_ success: Bool) {
+            if gate.claim() { task?.setTaskCompleted(success: success) }
+        }
+        guard manual || defaults.bool(forKey: enabledKey) else { finish(true); return }
+        guard compactWorkIsDue(now: now, manual: manual) else {
+            if manual, defaults.bool(forKey: hostHandoffKey) {
+                notify(title: "Refresh awaiting verification", body: "A host replacement is still pending. Reopen LiveContainer and check the installed profile before retrying.", kind: "host_handoff")
+            }
+            print("[LIVE_CONTAINER_REFRESH] NO_OP source=\(source)")
+            finish(true)
+            if task != nil { schedule() }
+            return
+        }
+        if source == "bgapprefresh" {
+            print("[LIVE_CONTAINER_REFRESH] WATCHDOG_DUE action=resubmit_bgprocessing")
+            schedule()
+            finish(true)
+            return
+        }
+        guard let runID = beginRun(source: source, manual: manual) else {
+            print("[LIVE_CONTAINER_REFRESH] RUN_COALESCED source=\(source)")
+            finish(true)
+            return
+        }
+        defer { endRun(runID); schedule() }
+        do {
+            try await performRefresh(runID: runID)
+            let verification = verifyRefreshManifest(runID: runID.uuidString)
+            if verification.hostHandoff {
+                guard gate.claim() else { return }
+                defaults.set("HOST_REFRESH_AWAITING_RELAUNCH", forKey: healthStateKey)
+                record(source: source, result: "host_handoff_awaiting_relaunch", detail: verification.reason)
+                notify(title: "Host refresh awaiting verification", body: "Reopen LiveContainer to check that its installed profile renewed.", kind: "host_handoff")
+                // Completion of this handler is not a claim of refresh success.
+                task?.setTaskCompleted(success: false)
+            } else if verification.verified {
+                let guestsValid = verifyGuestSignatures()
+                try Task.checkCancellation()
+                guard gate.claim() else { return }
+                if guestsValid {
+                    markVerified(source: source, detail: "All requested installed-app results were confirmed.")
+                    print("[LIVE_CONTAINER_REFRESH] REFRESH_RESULT run_id=\(runID.uuidString) success=true verified=true")
+                    task?.setTaskCompleted(success: true)
+                } else {
+                    defaults.set("GUEST_SIGNATURE_INVALID", forKey: healthStateKey)
+                    record(source: source, result: "guest_signature_invalid", detail: "A guest could not be verified. Host refresh does not re-sign every guest.")
+                    notify(title: "Guest signature needs attention", body: "Open the affected guest in LiveContainer to check its signing status.", kind: "guest_invalid")
+                    task?.setTaskCompleted(success: false)
+                }
+            } else {
+                throw NSError(domain: "LiveContainerRefresh.Verification", code: 1001,
+                    userInfo: [NSLocalizedDescriptionKey: verification.reason])
+            }
+        } catch {
+            guard gate.claim() else { return } // Expiration already recorded the outcome.
+            let nsError = error as NSError
+            let count = defaults.integer(forKey: retryCountKey) + 1
+            defaults.set(count, forKey: retryCountKey)
+            if !(error is CancellationError), !LiveContainerRefreshPolicy.isUserActionFailure(nsError),
+               let delay = LiveContainerRefreshPolicy.retryDelay(failureCount: count) {
+                defaults.set(Date().addingTimeInterval(delay), forKey: nextRetryKey)
+            } else {
+                defaults.removeObject(forKey: nextRetryKey)
+                defaults.set(true, forKey: retryExhaustedKey)
+            }
+            defaults.set("REFRESH_FAILED", forKey: healthStateKey)
+            defaults.set(error.localizedDescription, forKey: lastErrorKey)
+            record(source: source, result: "failure", detail: error.localizedDescription)
+            print("[LIVE_CONTAINER_REFRESH] REFRESH_RESULT run_id=\(runID.uuidString) success=false verified=false error_domain=\(nsError.domain) error_code=\(nsError.code) error=\(error.localizedDescription)")
+            notify(title: "Refresh failed", body: error.localizedDescription, kind: "failed")
+            task?.setTaskCompleted(success: false)
+        }
+    }
+
+    private static func handle(_ task: BGTask, source: String) {
+        let gate = LiveContainerRefreshCompletionGate()
+        let work = Task { @MainActor in await execute(source: source, task: task, gate: gate) }
+        task.expirationHandler = {
+            work.cancel()
+            guard gate.claim() else { return }
+            task.setTaskCompleted(success: false)
+            Task { @MainActor in
+                defaults.set("REFRESH_INTERRUPTED", forKey: healthStateKey)
+                let count = defaults.integer(forKey: retryCountKey) + 1
+                defaults.set(count, forKey: retryCountKey)
+                if let delay = LiveContainerRefreshPolicy.retryDelay(failureCount: count) {
+                    defaults.set(Date().addingTimeInterval(delay), forKey: nextRetryKey)
+                } else { defaults.set(true, forKey: retryExhaustedKey) }
+                record(source: source, result: "expired", detail: "iOS ended the background execution window; refresh was not verified.")
+                notify(title: "Refresh interrupted", body: "iOS ended background execution before completion. Open LiveContainer to check the result.", kind: "expired")
+            }
+        }
+    }
+
+    static func register() {
+        guard !registered else { return }
+        registered = true
+        hostBundle = Bundle.main
+        // A durable marker from a terminated process is not a live mutex.
+        if defaults.string(forKey: activeRunKey) != nil {
+            defaults.removeObject(forKey: activeRunKey)
+            record(source: "relaunch", result: "interrupted", detail: "The previous process ended before recording completion.")
+        }
+        do {
+            let resolved = try LiveContainerRefreshTaskIdentifiers.resolve(info: hostBundle?.infoDictionary ?? [:])
+            identifiers = resolved
+            processingRegistered = BGTaskScheduler.shared.register(forTaskWithIdentifier: resolved.processing, using: nil) { task in
+                Task { @MainActor in handle(task, source: "bgprocessing") }
+            }
+            watchdogRegistered = BGTaskScheduler.shared.register(forTaskWithIdentifier: resolved.watchdog, using: nil) { task in
+                Task { @MainActor in handle(task, source: "bgapprefresh") }
+            }
+            print("[LIVE_CONTAINER_REFRESH] REGISTER_PASS processing=\(processingRegistered) watchdog=\(watchdogRegistered) task_id=\(resolved.processing)")
+            if !processingRegistered || !watchdogRegistered {
+                record(source: "scheduler", result: "registration_limited", detail: "iOS did not register every background task. Manual refresh remains available.")
+            }
+        } catch {
+            defaults.set("foreground_recovery_only", forKey: strategyKey)
+            defaults.set(error.localizedDescription, forKey: lastErrorKey)
+            record(source: "scheduler", result: "configuration_failed", detail: error.localizedDescription)
+        }
+    }
+
+    static func requestRefreshNow() async { await execute(source: "alarm_action") }
+    static func runNow() {
+        Task { @MainActor in
+            await requestNotificationPermission()
+            verifyPendingHostHandoff()
+            await execute(source: "manual")
+        }
+    }
+
+    static func recoverAfterLaunchOrResume() {
+        guard activeRun == nil else { return }
+        verifyPendingHostHandoff()
+        observeMissedDeadline(now: Date())
+        guard defaults.bool(forKey: enabledKey), defaults.object(forKey: earliestEligibleKey) != nil,
+              compactWorkIsDue(now: Date()) else { return }
+        Task { @MainActor in await execute(source: "launch_or_resume") }
+    }
+
+    static func scheduleChanged() {
+        cancelDeadlineProtection()
+        defaults.removeObject(forKey: deadlineKey)
+        defaults.removeObject(forKey: satisfiedDeadlineKey)
+        defaults.set(false, forKey: retryExhaustedKey)
+        defaults.set(0, forKey: retryCountKey)
+        schedule()
+        if defaults.bool(forKey: enabledKey) {
+            Task { @MainActor in await requestNotificationPermission(); schedule() }
+        }
+    }
+
+    static func cancelDeadlineProtection() {
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [warningIdentifier])
+        if #available(iOS 26.1, *), defaults.bool(forKey: alarmScheduledKey) {
+            LiveContainerAutoRefreshAlarmProvider.cancelIfAvailable()
+        }
+    }
+
+    private static func scheduleDeadlineWarning(_ deadline: Date) {
+        guard deadline > Date() else { return }
+        let content = UNMutableNotificationContent()
+        content.title = "Automatic refresh needs checking"
+        content.body = "No completed refresh has been confirmed for this deadline. Open LiveContainer to check or refresh. A host replacement may still need verification."
+        content.sound = .default
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: max(1, deadline.timeIntervalSinceNow), repeats: false)
+        UNUserNotificationCenter.current().add(UNNotificationRequest(identifier: warningIdentifier, content: content, trigger: trigger)) { error in
+            if let error { print("[LIVE_CONTAINER_REFRESH] DEADLINE_WARNING_FAIL error=\(error.localizedDescription)") }
+        }
+    }
+
+    static func schedule() {
+        guard defaults.bool(forKey: enabledKey) else {
+            if let ids = identifiers {
+                BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: ids.processing)
+                BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: ids.watchdog)
+            }
+            cancelDeadlineProtection()
+            defaults.set("disabled", forKey: strategyKey)
+            return
+        }
+        let now = Date()
+        observeMissedDeadline(now: now)
+        var deadline = defaults.object(forKey: deadlineKey) as? Date
+        if deadline == nil || deadline == (defaults.object(forKey: satisfiedDeadlineKey) as? Date) ||
+            (defaults.bool(forKey: retryExhaustedKey) && (deadline ?? now) < now) {
+            deadline = nextDate(after: now)
+            defaults.set(deadline, forKey: deadlineKey)
+            defaults.removeObject(forKey: nextRetryKey)
+            defaults.set(false, forKey: retryExhaustedKey)
+            defaults.set(0, forKey: retryCountKey)
+        }
+        guard let deadline else { return }
+        scheduleDeadlineWarning(deadline) // Pre-scheduled; does not require a future app wake.
+        defaults.set(processingRegistered ? "native_without_alarmkit" : "foreground_recovery_only", forKey: strategyKey)
+        if let ids = identifiers, processingRegistered, !defaults.bool(forKey: retryExhaustedKey), !defaults.bool(forKey: hostHandoffKey) {
+            let earliest = LiveContainerRefreshPolicy.earliestUsefulDate(now: now, deadline: deadline, lead: leadTime,
+                eligible: defaults.object(forKey: earliestEligibleKey) as? Date,
+                retry: defaults.object(forKey: nextRetryKey) as? Date)
+            let request = BGProcessingTaskRequest(identifier: ids.processing)
+            request.requiresNetworkConnectivity = true
+            request.requiresExternalPower = false
+            request.earliestBeginDate = earliest
+            do {
+                try BGTaskScheduler.shared.submit(request)
+                print("[LIVE_CONTAINER_REFRESH] SCHEDULE_PASS target_deadline=\(deadline.timeIntervalSince1970) earliest_begin=\(earliest.timeIntervalSince1970)")
+            } catch {
+                defaults.set(error.localizedDescription, forKey: lastErrorKey)
+                record(source: "scheduler", result: "bgprocessing_submit_failed", detail: error.localizedDescription)
+            }
+            // A watchdog is one bounded opportunity, not a repeated polling job.
+            if watchdogRegistered, deadline > now {
+                let watchdog = BGAppRefreshTaskRequest(identifier: ids.watchdog)
+                watchdog.earliestBeginDate = deadline
+                do { try BGTaskScheduler.shared.submit(watchdog) }
+                catch { record(source: "scheduler", result: "bgapprefresh_submit_failed", detail: error.localizedDescription) }
+            }
+        }
+        if #available(iOS 26.1, *), deadline > now {
+            Task { @MainActor in await LiveContainerAutoRefreshAlarmProvider.scheduleIfAvailable(deadline: deadline) }
+        }
+    }
+
+    private static func nextDate(after now: Date) -> Date {
+        let frequency = defaults.string(forKey: frequencyKey) ?? "interval"
+        if frequency == "interval" { return now.addingTimeInterval(6 * 60 * 60) }
+        let minutes = max(0, min(1439, defaults.object(forKey: minutesKey) as? Int ?? 600))
+        var parts = DateComponents(hour: minutes / 60, minute: minutes % 60, second: 0)
+        if frequency == "weekly" { parts.weekday = max(1, min(7, defaults.object(forKey: weekdayKey) as? Int ?? 2)) }
+        return Calendar.autoupdatingCurrent.nextDate(after: now, matching: parts, matchingPolicy: .nextTime,
+            repeatedTimePolicy: .first) ?? now.addingTimeInterval(6 * 60 * 60)
+    }
+}

--- a/scripts/templates/livecontainer_refresh_settings.swift
+++ b/scripts/templates/livecontainer_refresh_settings.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+struct LCEmbeddedSideStoreRefreshView: View {
+    private let defaults = UserDefaults(suiteName: "group.com.SideStore.SideStore") ?? .standard
+    @State private var history: [[String: String]] = []
+    @AppStorage("liveContainerAutoRefreshEnabled", store: UserDefaults(suiteName: "group.com.SideStore.SideStore")) private var enabled = false
+    @AppStorage("liveContainerAutoRefreshFrequency", store: UserDefaults(suiteName: "group.com.SideStore.SideStore")) private var frequency = "interval"
+    @AppStorage("liveContainerAutoRefreshWeekday", store: UserDefaults(suiteName: "group.com.SideStore.SideStore")) private var weekday = 2
+    @AppStorage("liveContainerAutoRefreshMinutes", store: UserDefaults(suiteName: "group.com.SideStore.SideStore")) private var minutes = 600
+
+    private var time: Binding<Date> {
+        Binding(get: {
+            Calendar.autoupdatingCurrent.date(bySettingHour: minutes / 60, minute: minutes % 60, second: 0, of: Date()) ?? Date()
+        }, set: { value in
+            let parts = Calendar.autoupdatingCurrent.dateComponents([.hour, .minute], from: value)
+            minutes = (parts.hour ?? 10) * 60 + (parts.minute ?? 0)
+            notifyScheduleChanged()
+        })
+    }
+
+    var body: some View {
+        Form {
+            Section("Status") {
+                Text("Auto Refresh: \(enabled ? "Enabled" : "Disabled")")
+                let strategy = defaults.string(forKey: "liveContainerAutoRefreshStrategy") ?? "foreground_recovery_only"
+                let protection = strategy == "native_full" ? "Enhanced" :
+                    (strategy == "native_without_alarmkit" ? "Standard" : "Limited")
+                Text("Protection: \(protection)")
+                Text("Background execution remains best-effort. A scheduled request is not a completed refresh.")
+                    .font(.caption).foregroundColor(.secondary)
+                if let error = defaults.string(forKey: "liveContainerAutoRefreshLastError"), !error.isEmpty {
+                    Text(error).font(.caption).foregroundColor(.red)
+                }
+            }
+            Section {
+                Toggle("Scheduled refresh", isOn: Binding(get: { enabled }, set: { enabled = $0; notifyScheduleChanged() }))
+                Button("Refresh SideStore now", action: notifyManualRefresh)
+                Picker("Frequency", selection: Binding(get: { frequency }, set: { frequency = $0; notifyScheduleChanged() })) {
+                    Text("Every six hours").tag("interval")
+                    Text("Daily").tag("daily")
+                    Text("Weekly").tag("weekly")
+                }.disabled(!enabled)
+                if frequency == "weekly" {
+                    Picker("Weekday", selection: Binding(get: { weekday }, set: { weekday = $0; notifyScheduleChanged() })) {
+                        ForEach(1...7, id: \.self) { day in Text(Calendar.autoupdatingCurrent.weekdaySymbols[day - 1]).tag(day) }
+                    }.disabled(!enabled)
+                    Text("A weekly schedule can be too late for free-account signing. Prefer daily refresh.")
+                        .font(.caption).foregroundColor(.secondary)
+                }
+                if frequency != "interval" {
+                    DatePicker("Target time (local)", selection: time, displayedComponents: .hourAndMinute).disabled(!enabled)
+                }
+                Text("Refresh can start before the target time to allow for iOS scheduling delays.")
+                    .font(.caption).foregroundColor(.secondary)
+            }
+            Section("Warnings") {
+                Button("Allow refresh notifications") {
+                    Task { @MainActor in await LiveContainerAutoRefreshScheduler.requestNotificationPermission(); LiveContainerAutoRefreshScheduler.schedule() }
+                }
+                if #available(iOS 26.1, *) {
+                    Button("Enable optional deadline alarm") {
+                        Task { @MainActor in await LiveContainerAutoRefreshAlarmProvider.requestAuthorization() }
+                    }
+                }
+                Text("Warnings require permission. A deadline warning asks you to check an unconfirmed refresh; it cannot diagnose a task that never ran.")
+                    .font(.caption).foregroundColor(.secondary)
+            }
+            if let result = defaults.string(forKey: "liveContainerAutoRefreshLastResult") {
+                Section("Last result") {
+                    Text(result.replacingOccurrences(of: "_", with: " ").capitalized)
+                    if let date = defaults.object(forKey: "liveContainerAutoRefreshLastDate") as? Date {
+                        Text(date.formatted(date: .abbreviated, time: .shortened)).font(.caption)
+                    }
+                }
+            }
+            Section("History") {
+                if history.isEmpty { Text("No refreshes recorded").foregroundColor(.secondary) }
+                ForEach(Array(history.prefix(20).enumerated()), id: \.offset) { _, entry in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("\(entry["source"]?.capitalized ?? "Unknown") - \(entry["result"]?.capitalized ?? "Unknown")")
+                        Text(entry["date"] ?? "").font(.caption).foregroundColor(.secondary)
+                        if let detail = entry["detail"], !detail.isEmpty { Text(detail).font(.caption2).foregroundColor(.secondary) }
+                    }
+                }
+            }
+        }
+        .navigationTitle("SideStore refresh")
+        .onAppear { reloadHistory() }
+        .onReceive(NotificationCenter.default.publisher(for: Notification.Name("LiveContainerAutoRefreshHistoryChanged")).receive(on: RunLoop.main)) { _ in reloadHistory() }
+    }
+
+    private func notifyScheduleChanged() {
+        NotificationCenter.default.post(name: Notification.Name("LiveContainerAutoRefreshScheduleChanged"), object: nil)
+    }
+    private func notifyManualRefresh() {
+        NotificationCenter.default.post(name: Notification.Name("LiveContainerAutoRefreshRunNow"), object: nil)
+    }
+    private func reloadHistory() { history = defaults.array(forKey: "liveContainerAutoRefreshHistory") as? [[String: String]] ?? [] }
+}

--- a/tests/fixtures/livecontainer_scheduler_harness.swift
+++ b/tests/fixtures/livecontainer_scheduler_harness.swift
@@ -1,0 +1,70 @@
+extension LiveContainerAutoRefreshScheduler {
+    static func clearTestState() {
+        for key in defaults.dictionaryRepresentation().keys where key.hasPrefix("liveContainerAutoRefresh") { defaults.removeObject(forKey: key) }
+        activeRun = nil
+        LiveContainerRefreshBridge.calls = 0
+        LiveContainerRefreshBridge.fails = false
+        LiveContainerRefreshBridge.incomplete = false
+        BGTaskScheduler.shared.requests = []
+        UNUserNotificationCenter.shared.requests = []
+    }
+    static func exercise() async {
+        clearTestState()
+        let noOp = BGTask()
+        defaults.set(true, forKey: enabledKey)
+        defaults.set(Date().addingTimeInterval(3600), forKey: earliestEligibleKey)
+        await execute(source: "bgprocessing", task: noOp)
+        precondition(LiveContainerRefreshBridge.calls == 0 && noOp.completions == [true])
+
+        clearTestState()
+        let disabled = BGTask()
+        await execute(source: "bgprocessing", task: disabled)
+        precondition(LiveContainerRefreshBridge.calls == 0 && disabled.completions == [true])
+
+        clearTestState()
+        let successful = BGTask()
+        await execute(source: "manual", task: successful)
+        precondition(LiveContainerRefreshBridge.calls == 1 && successful.completions == [true])
+        precondition(defaults.string(forKey: lastResultKey) == "verified")
+        precondition(defaults.string(forKey: activeRunKey) == nil)
+        precondition(defaults.string(forKey: expectedRunKey) == nil)
+
+        clearTestState()
+        LiveContainerRefreshBridge.fails = true
+        let failed = BGTask()
+        await execute(source: "manual", task: failed)
+        precondition(failed.completions == [false])
+        precondition(defaults.string(forKey: lastResultKey) == "failure")
+        precondition(defaults.object(forKey: nextRetryKey) as? Date != nil)
+        precondition(UNUserNotificationCenter.shared.requests.contains { $0.content.title == "Refresh failed" })
+
+        clearTestState()
+        LiveContainerRefreshBridge.incomplete = true
+        let omitted = BGTask()
+        await execute(source: "manual", task: omitted)
+        precondition(omitted.completions == [false])
+        precondition(defaults.string(forKey: lastErrorKey) == "verification_manifest_incomplete")
+
+        clearTestState()
+        activeRun = UUID()
+        let coalesced = BGTask()
+        await execute(source: "manual", task: coalesced)
+        precondition(coalesced.completions == [true] && LiveContainerRefreshBridge.calls == 0)
+
+        clearTestState()
+        let ended = BGTask()
+        let gate = LiveContainerRefreshCompletionGate()
+        precondition(gate.claim())
+        ended.setTaskCompleted(success: false)
+        await execute(source: "manual", task: ended, gate: gate)
+        precondition(ended.completions == [false])
+        precondition(defaults.string(forKey: lastResultKey) != "verified")
+        clearTestState()
+        print("SCHEDULER_BEHAVIOR_TESTS_PASSED")
+    }
+}
+
+@main
+struct SchedulerTestMain {
+    @MainActor static func main() async { await LiveContainerAutoRefreshScheduler.exercise() }
+}

--- a/tests/fixtures/livecontainer_scheduler_stubs.swift
+++ b/tests/fixtures/livecontainer_scheduler_stubs.swift
@@ -1,0 +1,72 @@
+// Test doubles for the OS APIs. These verify our Swift types and coordinator
+// behavior, NOT iOS delivery, transport, signing, or physical-device execution.
+import Foundation
+class BGTask {
+    var expirationHandler: (() -> Void)?
+    var completions: [Bool] = []
+    func setTaskCompleted(success: Bool) { completions.append(success) }
+}
+class BGProcessingTask: BGTask {}
+class BGAppRefreshTask: BGTask {}
+class BGTaskRequest { let identifier: String; var earliestBeginDate: Date?; init(identifier: String) { self.identifier = identifier } }
+class BGProcessingTaskRequest: BGTaskRequest { var requiresNetworkConnectivity = false; var requiresExternalPower = false }
+class BGAppRefreshTaskRequest: BGTaskRequest {}
+class BGTaskScheduler {
+    static let shared = BGTaskScheduler()
+    var requests: [BGTaskRequest] = []
+    var reject = false
+    func register(forTaskWithIdentifier identifier: String, using queue: DispatchQueue?, launchHandler: @escaping (BGTask) -> Void) -> Bool { true }
+    func submit(_ request: BGTaskRequest) throws {
+        if reject { throw NSError(domain: "BGTaskSchedulerErrorDomain", code: 3) }
+        requests.append(request)
+    }
+    func cancel(taskRequestWithIdentifier identifier: String) {}
+}
+enum UNAuthorizationStatus { case notDetermined, denied, authorized, provisional }
+struct UNAuthorizationOptions: OptionSet {
+    let rawValue: Int
+    static let alert = Self(rawValue: 1); static let sound = Self(rawValue: 2)
+}
+struct UNNotificationSettings { var authorizationStatus: UNAuthorizationStatus = .authorized }
+struct UNNotificationSound { static let `default` = Self() }
+class UNMutableNotificationContent { var title = ""; var body = ""; var sound: UNNotificationSound? }
+class UNTimeIntervalNotificationTrigger { init(timeInterval: TimeInterval, repeats: Bool) {} }
+class UNNotificationRequest {
+    let identifier: String; let content: UNMutableNotificationContent
+    init(identifier: String, content: UNMutableNotificationContent, trigger: UNTimeIntervalNotificationTrigger?) { self.identifier = identifier; self.content = content }
+}
+class UNUserNotificationCenter {
+    static let shared = UNUserNotificationCenter()
+    static func current() -> UNUserNotificationCenter { shared }
+    var requests: [UNNotificationRequest] = []
+    func notificationSettings() async -> UNNotificationSettings { UNNotificationSettings() }
+    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool { true }
+    func getNotificationSettings(_ completion: (UNNotificationSettings) -> Void) { completion(UNNotificationSettings()) }
+    func add(_ request: UNNotificationRequest, withCompletionHandler completion: ((Error?) -> Void)? = nil) { requests.append(request); completion?(nil) }
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {}
+}
+class FakeAppInfo { func bundlePath() -> String? { nil }; func bundleIdentifier() -> String { "test.guest" } }
+struct FakeGuest { var appInfo = FakeAppInfo() }
+class FakeModel { var apps: [FakeGuest] = []; var hiddenApps: [FakeGuest] = [] }
+class DataManager { static let shared = DataManager(); var model = FakeModel() }
+func checkCodeSignature(_ path: UnsafePointer<CChar>) -> Bool { true }
+@MainActor
+enum LiveContainerRefreshBridge {
+    static var calls = 0
+    static var fails = false
+    static var incomplete = false
+    static func refreshAllApps() async throws {
+        calls += 1
+        if fails { throw NSError(domain: "test.refresh", code: 42, userInfo: [NSLocalizedDescriptionKey: "transport failed"]) }
+        let defaults = LiveContainerAutoRefreshScheduler.defaults
+        defaults.set(["run_id": defaults.string(forKey: "liveContainerAutoRefreshExpectedRunID") ?? "",
+                      "expected_ids": incomplete ? ["spotify", "other"] : ["spotify"],
+                      "results": [["bundle_id": "spotify", "success": true]]],
+                     forKey: "liveContainerAutoRefreshVerification")
+    }
+}
+@MainActor
+enum LiveContainerAutoRefreshAlarmProvider {
+    static func cancelIfAvailable() {}
+    static func scheduleIfAvailable(deadline: Date) async {}
+}

--- a/tests/test_combined_refresh_contract.py
+++ b/tests/test_combined_refresh_contract.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import importlib.util
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("combined_contract", ROOT / "scripts/patch_combined_refresh_contract.py")
+patch = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(patch)
+
+
+class CombinedRefreshContractTests(unittest.TestCase):
+    def test_handoff_uses_host_run_and_manifest_counts_expected_apps(self):
+        source = r'''
+    private func automaticRefreshDefaults() -> UserDefaults { .standard }
+    private func persistAutomaticHostHandoff() {
+        defaults.set(refreshIdentifier, forKey: "liveContainerAutoRefreshHostHandoffRunID")
+        debugLog("[AUTO_REFRESH] HOST_REFRESH_HANDOFF_STARTED run_id=\\(refreshIdentifier)")
+    }
+    private func persistAutomaticRefreshVerification() {
+        defaults.set(["version": 1, "date": Date(), "results": []], forKey: "manifest")
+    }
+    private func startListeningForRunningApps() {}
+'''
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            file = root / "SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift"
+            file.parent.mkdir(parents=True)
+            file.write_text(source)
+            patch.patch(root)
+            result = file.read_text()
+            self.assertIn('"expected_ids": installedApps.map', result)
+            self.assertIn('"version": 2', result)
+            self.assertIn('defaults.string(forKey: "liveContainerAutoRefreshExpectedRunID") ?? refreshIdentifier', result)
+            self.assertNotIn(r"\\(refreshIdentifier)", result)
+            patch.patch(root)
+            self.assertEqual(result, file.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_combined_refresh_contract.py
+++ b/tests/test_combined_refresh_contract.py
@@ -31,6 +31,7 @@ class CombinedRefreshContractTests(unittest.TestCase):
             result = file.read_text()
             self.assertIn('"expected_ids": installedApps.map', result)
             self.assertIn('"version": 2', result)
+            self.assertIn('"schema": "LiveContainerRefreshManifestV2"', result)
             self.assertIn('defaults.string(forKey: "liveContainerAutoRefreshExpectedRunID") ?? refreshIdentifier', result)
             self.assertNotIn(r"\\(refreshIdentifier)", result)
             patch.patch(root)

--- a/tests/test_livecontainer.py
+++ b/tests/test_livecontainer.py
@@ -1,129 +1,172 @@
-"""Static and idempotence checks for the LiveContainer integration patch."""
-
+"""Generated Swift regression tests, real policy execution, and patch idempotence."""
 from pathlib import Path
 import importlib.util
+import os
+import plistlib
+import shutil
+import subprocess
 import tempfile
 import unittest
 
-
 ROOT = Path(__file__).resolve().parents[1]
-SPEC = importlib.util.spec_from_file_location(
-    "livecontainer_patch", ROOT / "scripts" / "patch_livecontainer_autorefresh.py"
-)
+SPEC = importlib.util.spec_from_file_location("livecontainer_patch", ROOT / "scripts/patch_livecontainer_autorefresh.py")
 patch = importlib.util.module_from_spec(SPEC)
-assert SPEC.loader is not None
 SPEC.loader.exec_module(patch)
 
 
-class LiveContainerPatchTests(unittest.TestCase):
-    def test_patch_script_compiles_and_has_required_contract(self):
-        source = (ROOT / "scripts" / "patch_livecontainer_autorefresh.py").read_text()
-        for marker in (
-            "BGTaskScheduler.shared.register",
-            "LiveContainerRefreshBridge",
-            "16SideStoreSupport20RefreshAllAppsIntentV",
-            'static let taskIdentifier = "\\(Bundle.main.bundleIdentifier',
-            "requestNotificationPermission",
-            "NOTIFICATION_PASS",
-            "Refresh started",
-            "Refresh completed",
-            "Refresh failed",
-            "requiresNetworkConnectivity = true",
-            "liveContainerAutoRefreshFrequency",
-            "liveContainerAutoRefreshHistory",
-            "LiveContainerAutoRefreshHistoryChanged",
-            "reloadHistory()",
-            "Refresh SideStore now",
-            "RUN_BEGIN source=",
-            "BGTaskSchedulerPermittedIdentifiers",
-            "SideStoreSupport.framework in Frameworks",
-            "BGAppRefreshTask",
-            "liveContainerAutoRefreshEarliestEligibleAt",
-            "liveContainerAutoRefreshHostHandoff",
-            "LiveContainerAutoRefreshAlarmProvider",
-            "verifyRefreshManifest",
-            "HOST_REFRESH_AWAITING_RELAUNCH",
-            "HOST_REFRESH_VERIFIED",
-            "recoverAfterLaunchOrResume",
-            "native_without_alarmkit",
-            "Protection:",
-            "Enhanced",
-        ):
-            self.assertIn(marker, source)
-        self.assertNotIn('mangledName: "9SideStore20RefreshAllAppsIntentV"', source)
-        workflow = (ROOT / ".github/workflows/livecontainer-build.yml").read_text(encoding="utf-8")
-        self.assertIn("module.patch_console_log", workflow)
-        self.assertIn("LIVE_REFRESH_LOG_RETENTION_V1", workflow)
+def fixture(root: Path) -> None:
+    for directory in ("SideStoreSupport", "LiveContainerSwiftUI/App", "LiveContainerSwiftUI/Views/Settings", "LiveContainer.xcodeproj", "LiveContainer"):
+        (root / directory).mkdir(parents=True)
+    (root / "SideStoreSupport/SideStore.swift").write_text("import Foundation\n\nclass RefreshHandler: NSObject, RefreshServer {\n}\n")
+    (root / "LiveContainerSwiftUI/App/AppDelegate.swift").write_text(
+        "import UIKit\nimport SwiftUI\nimport Intents\n\n@objc class AppDelegate: UIResponder, UIApplicationDelegate {\n"
+        "    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? ) -> Bool {\n"
+        "        application.shortcutItems = nil\n        return true\n    }\n}\n\nclass SceneDelegate: NSObject {}\n")
+    (root / "LiveContainer/Info.plist").write_bytes(plistlib.dumps({
+        "CFBundleIdentifier": "com.kdt.livecontainer", "MinimumOSVersion": "15.0",
+        "BGTaskSchedulerPermittedIdentifiers": ["upstream.existing.task"], "UIBackgroundModes": ["audio"]}))
+    (root / "LiveContainer.xcodeproj/project.pbxproj").write_text(
+        "/* Begin PBXBuildFile section */\n"
+        "17413FB22D9C0BAE00F3F928 /* Frameworks */ = {\n\t\t\tisa = PBXFrameworksBuildPhase;\n\t\t\tbuildActionMask = 2147483647;\n\t\t\tfiles = (\n\t\t\t\t);\n};\n"
+        "17554B6A2DA165D8004C6D90 /* Frameworks */ = {\n\t\t\tisa = PBXFrameworksBuildPhase;\n\t\t\tbuildActionMask = 2147483647;\n\t\t\tfiles = (\n\t\t\t);\n};\n"
+        "/* Begin PBXTargetDependency section */\n/* End PBXTargetDependency section */\n"
+        "17413FB42D9C0BAE00F3F928 /* LiveContainerSwiftUI */ = {\n\t\t\tisa = PBXNativeTarget;\n\t\t\tdependencies = (\n\t\t\t);\n\t\t\tfileSystemSynchronizedGroups = (\n\t\t\t\t17413FB62D9C0BAE00F3F928 /* LiveContainerSwiftUI */\n\t\t\t);\n};\n"
+        '\t\t\t\tOTHER_LDFLAGS = (\n\t\t\t\t\t"-e",\n\t\t\t\t\t_LiveContainerMainC,\n\t\t\t\t);\n'
+        "IPHONEOS_DEPLOYMENT_TARGET = 15.0;\n")
+    (root / "LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift").write_text(
+        "struct LCSettingsView: View {\n    var body: some View {\n        NavigationView {\n            Form {\n            }\n        }\n    }\n}\n")
 
+
+def apply(root: Path) -> None:
+    for operation in (patch.patch_support, patch.patch_host_delegate, patch.patch_host_info,
+                      patch.patch_project, patch.patch_alarm_provider, patch.patch_settings):
+        operation(root)
+    patch.verify(root)
+
+
+class LiveContainerPatchTests(unittest.TestCase):
     def test_generated_host_fragments_are_idempotent(self):
-        # Exercise the generator's own insertion helpers without requiring an
-        # Xcode installation or network access in the repository test job.
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            (root / "SideStoreSupport").mkdir(parents=True)
-            (root / "LiveContainerSwiftUI/App").mkdir(parents=True)
-            (root / "LiveContainerSwiftUI/Views/Settings").mkdir(parents=True)
-            (root / "LiveContainer.xcodeproj").mkdir()
-            (root / "LiveContainer").mkdir(parents=True)
-            (root / "SideStoreSupport/SideStore.swift").write_text(
-                "import Foundation\n\nclass RefreshHandler: NSObject, RefreshServer {\n"
-            )
-            (root / "LiveContainerSwiftUI/App/AppDelegate.swift").write_text(
-                "import UIKit\nimport SwiftUI\nimport Intents\n\n@objc class AppDelegate: UIResponder, UIApplicationDelegate {\n"
-                "    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? ) -> Bool {\n"
-                "        application.shortcutItems = nil\n        return true\n    }\n\n"
-                "    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration { return UISceneConfiguration() }\n}\n\nclass SceneDelegate: NSObject {}\n"
-            )
-            (root / "LiveContainer/Info.plist").write_text("<?xml version=\"1.0\"?><plist><dict></dict>\n</plist>\n")
-            (root / "LiveContainer.xcodeproj/project.pbxproj").write_text(
-                "/* Begin PBXBuildFile section */\n"
-                "17413FB22D9C0BAE00F3F928 /* Frameworks */ = {\n"
-                "\t\t\tisa = PBXFrameworksBuildPhase;\n"
-                "\t\t\tbuildActionMask = 2147483647;\n"
-                "\t\t\tfiles = (\n"
-                "\t\t\t\t);\n"
-                "};\n"
-                "17554B6A2DA165D8004C6D90 /* Frameworks */ = {\n"
-                "\t\t\tisa = PBXFrameworksBuildPhase;\n"
-                "\t\t\tbuildActionMask = 2147483647;\n"
-                "\t\t\tfiles = (\n"
-                "\t\t\t);\n"
-                "};\n"
-                "/* Begin PBXTargetDependency section */\n"
-                "/* End PBXTargetDependency section */\n"
-                "17413FB42D9C0BAE00F3F928 /* LiveContainerSwiftUI */ = {\n"
-                "\t\t\tisa = PBXNativeTarget;\n"
-                "\t\t\tbuildConfigurationList = 17413FBE2D9C0BAE00F3F928;\n"
-                "\t\t\tbuildPhases = ();\n"
-                "\t\t\tdependencies = (\n"
-                "\t\t\t);\n"
-                "\t\t\tfileSystemSynchronizedGroups = (\n"
-                "\t\t\t\t17413FB62D9C0BAE00F3F928 /* LiveContainerSwiftUI */\n"
-                "\t\t\t);\n"
-                "};\n"
-                "\t\t\t\tOTHER_LDFLAGS = (\n"
-                "\t\t\t\t\t\"-e\",\n"
-                "\t\t\t\t\t_LiveContainerMainC,\n"
-                "\t\t\t\t);\n"
-            )
-            (root / "LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift").write_text(
-                "struct LCSettingsView: View {\n    var body: some View {\n        NavigationView {\n            Form {\n            }\n        }\n    }\n}\n"
-            )
-            patch.patch_support(root)
-            patch.patch_host_delegate(root)
-            patch.patch_host_info(root)
-            patch.patch_project(root)
-            patch.patch_alarm_provider(root)
-            patch.patch_settings(root)
-            patch.verify(root)
-            first = { path: path.read_text() for path in root.rglob("*") if path.is_file() }
-            patch.patch_support(root)
-            patch.patch_host_delegate(root)
-            patch.patch_host_info(root)
-            patch.patch_project(root)
-            patch.patch_alarm_provider(root)
-            patch.patch_settings(root)
-            self.assertEqual(first, {path: path.read_text() for path in root.rglob("*") if path.is_file()})
+            fixture(root)
+            apply(root)
+            first = {p.relative_to(root): p.read_bytes() for p in root.rglob("*") if p.is_file()}
+            apply(root)
+            self.assertEqual(first, {p.relative_to(root): p.read_bytes() for p in root.rglob("*") if p.is_file()})
+            info = plistlib.loads((root / "LiveContainer/Info.plist").read_bytes())
+            self.assertEqual(info["MinimumOSVersion"], "15.0")
+            self.assertEqual(set(info["UIBackgroundModes"]), {"audio", "processing", "fetch"})
+            self.assertIn("upstream.existing.task", info["BGTaskSchedulerPermittedIdentifiers"])
+            self.assertEqual(len(info["BGTaskSchedulerPermittedIdentifiers"]), 3)
+
+    def test_templates_have_no_python_double_escaping(self):
+        self.assertNotIn(r'\\(', patch.HOST_SCHEDULER)
+        self.assertNotIn('?? \\"com.kdt.livecontainer', patch.HOST_SCHEDULER)
+        self.assertIn('16SideStoreSupport20RefreshAllAppsIntentV', patch.BRIDGE)
+        self.assertIn('identifier: "RefreshAllIntent"', patch.BRIDGE)
+        self.assertNotIn('9SideStore20RefreshAllAppsIntentV', patch.BRIDGE)
+        self.assertIn('LiveContainerRefreshTaskIdentifiers.resolve', patch.HOST_SCHEDULER)
+        self.assertNotIn('Bundle.main.bundleIdentifier ??', patch.HOST_SCHEDULER)
+
+    def test_plain_templates_parse_with_swift_compiler(self):
+        compiler = shutil.which("swiftc")
+        if not compiler:
+            self.skipTest("swiftc unavailable; generated Swift NOT validated locally")
+        for file in sorted((ROOT / "scripts/templates").glob("livecontainer_refresh_*.swift")):
+            result = subprocess.run([compiler, "-frontend", "-parse", str(file)], text=True, capture_output=True)
+            self.assertEqual(result.returncode, 0, f"{file.name}: {result.stderr}")
+
+    def test_failed_ci_interpolation_is_reproduced(self):
+        compiler = shutil.which("swiftc")
+        if not compiler:
+            self.skipTest("swiftc unavailable")
+        with tempfile.TemporaryDirectory() as directory:
+            file = Path(directory) / "Broken.swift"
+            file.write_text(r'let taskIdentifier = "\(Bundle.main.bundleIdentifier ?? \"com.kdt.livecontainer\").sidestore.automatic-refresh"')
+            result = subprocess.run([compiler, "-frontend", "-parse", str(file)], text=True, capture_output=True)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("string", result.stderr)
+
+    def test_policy_executes_with_signed_and_unmodified_allowlists(self):
+        compiler = shutil.which("swiftc")
+        if not compiler:
+            self.skipTest("swiftc unavailable")
+        source = (ROOT / "scripts/templates/livecontainer_refresh_policy.swift").read_text()
+        source += r'''
+let base = "com.kdt.livecontainer.sidestore.automatic-refresh"
+func info(_ id: String, modes: [String] = ["processing", "fetch"]) -> [String: Any] {
+    ["CFBundleIdentifier": "com.kdt.livecontainer.TESTTEAM", "BGTaskSchedulerPermittedIdentifiers": [id, id + ".watchdog"], "UIBackgroundModes": modes]
+}
+let original = try LiveContainerRefreshTaskIdentifiers.resolve(info: info(base))
+precondition(original.processing == base) // ordinary iLoader, no allowlist rewrite
+let rewritten = base.replacingOccurrences(of: "livecontainer.", with: "livecontainer.TESTTEAM.")
+let signedIDs = try LiveContainerRefreshTaskIdentifiers.resolve(info: info(rewritten))
+precondition(signedIDs.processing == rewritten)
+do { _ = try LiveContainerRefreshTaskIdentifiers.resolve(info: info(base, modes: ["processing"])); fatalError("missing fetch accepted") } catch {}
+do { _ = try LiveContainerRefreshTaskIdentifiers.resolve(info: [:]); fatalError("missing allowlist accepted") } catch {}
+let now = Date(timeIntervalSince1970: 1000)
+let deadline = now.addingTimeInterval(3600)
+let eligible = now.addingTimeInterval(4000)
+let retry = now.addingTimeInterval(5000)
+precondition(LiveContainerRefreshPolicy.earliestUsefulDate(now: now, deadline: deadline, lead: 3600, eligible: eligible, retry: retry) == retry)
+precondition(!LiveContainerRefreshPolicy.workIsDue(now: now, eligible: nil, retry: retry, pendingHandoff: false, retryExhausted: false, manual: false))
+precondition(!LiveContainerRefreshPolicy.workIsDue(now: now, eligible: nil, retry: nil, pendingHandoff: true, retryExhausted: false, manual: true))
+precondition(LiveContainerRefreshPolicy.workIsDue(now: now, eligible: eligible, retry: retry, pendingHandoff: false, retryExhausted: true, manual: true))
+precondition(!LiveContainerRefreshPolicy.workIsDue(now: now, eligible: nil, retry: nil, pendingHandoff: false, retryExhausted: true, manual: false))
+precondition(LiveContainerRefreshPolicy.retryDelay(failureCount: 1) == 300)
+precondition(LiveContainerRefreshPolicy.retryDelay(failureCount: 2) == 1200)
+precondition(LiveContainerRefreshPolicy.retryDelay(failureCount: 3) == 3600)
+precondition(LiveContainerRefreshPolicy.retryDelay(failureCount: 4) == nil)
+let gate = LiveContainerRefreshCompletionGate()
+precondition(gate.claim()); precondition(!gate.claim()); precondition(!gate.claim())
+let concurrentGate = LiveContainerRefreshCompletionGate()
+let winnersLock = NSLock(); var winners = 0
+DispatchQueue.concurrentPerform(iterations: 100) { _ in
+    if concurrentGate.claim() { winnersLock.lock(); winners += 1; winnersLock.unlock() }
+}
+precondition(winners == 1)
+let value = 42
+print("INTERPOLATION_VALUE=\(value)")
+print("POLICY_TESTS_PASSED")
+'''
+        with tempfile.TemporaryDirectory() as directory:
+            file = Path(directory) / "main.swift"
+            executable = Path(directory) / "policy-test"
+            file.write_text(source)
+            build = subprocess.run([compiler, "-swift-version", "5", str(file), "-o", str(executable)], text=True, capture_output=True)
+            self.assertEqual(build.returncode, 0, build.stderr)
+            result = subprocess.run([str(executable)], text=True, capture_output=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("INTERPOLATION_VALUE=42", result.stdout)
+            self.assertIn("POLICY_TESTS_PASSED", result.stdout)
+
+    def test_notification_and_completion_contract(self):
+        self.assertIn("await requestNotificationPermission()", patch.HOST_SCHEDULER)
+        self.assertIn("gate.claim()", patch.HOST_SCHEDULER)
+        self.assertIn("try Task.checkCancellation()", patch.HOST_SCHEDULER)
+        self.assertIn("UNTimeIntervalNotificationTrigger", patch.HOST_SCHEDULER)
+        self.assertIn("await LiveContainerAutoRefreshScheduler.requestRefreshNow()", patch.ALARM_PROVIDER)
+        self.assertIn("#if canImport(AlarmKit)", patch.ALARM_PROVIDER)
+        self.assertIn("@available(iOS 26.1, *)", patch.ALARM_PROVIDER)
+        self.assertNotIn("Timer.scheduledTimer", patch.HOST_SCHEDULER)
+        self.assertNotIn("Task.sleep", patch.HOST_SCHEDULER)
+
+    def test_pinned_host_integration_when_available(self):
+        source = os.environ.get("LIVE_CONTAINER_TEST_SOURCE")
+        if not source:
+            self.skipTest("LIVE_CONTAINER_TEST_SOURCE is not available")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for relative in ("SideStoreSupport/SideStore.swift", "LiveContainerSwiftUI/App/AppDelegate.swift", "LiveContainer/Info.plist",
+                             "LiveContainer.xcodeproj/project.pbxproj", "LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift"):
+                target = root / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(Path(source) / relative, target)
+            apply(root)
+            support = (root / "SideStoreSupport/SideStore.swift").read_text()
+            start = support.index("guard let client = self.client")
+            self.assertLess(support.index("self.c = c", start), support.index("client.refreshAllApps", start))
+            apply(root)
 
 
 if __name__ == "__main__":

--- a/tests/test_livecontainer_runtime.py
+++ b/tests/test_livecontainer_runtime.py
@@ -1,0 +1,64 @@
+"""Compile the actual scheduler against OS doubles; do not call this device proof."""
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class LiveContainerRuntimeTests(unittest.TestCase):
+    def test_scheduler_typechecks_and_executes_failure_paths(self):
+        compiler = shutil.which("swiftc")
+        if not compiler:
+            self.skipTest("swiftc unavailable")
+        paths = ["tests/fixtures/livecontainer_scheduler_stubs.swift", "scripts/templates/livecontainer_refresh_policy.swift",
+                 "scripts/templates/livecontainer_refresh_scheduler.swift", "tests/fixtures/livecontainer_scheduler_harness.swift"]
+        source = "\n".join((ROOT / p).read_text() for p in paths)
+        with tempfile.TemporaryDirectory() as directory:
+            file = Path(directory) / "Test.swift"
+            exe = Path(directory) / "scheduler-test"
+            file.write_text(source)
+            build = subprocess.run([compiler, "-swift-version", "5", "-parse-as-library", str(file), "-o", str(exe)], text=True, capture_output=True)
+            self.assertEqual(build.returncode, 0, build.stderr)
+            result = subprocess.run([str(exe)], text=True, capture_output=True, timeout=20)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("SCHEDULER_BEHAVIOR_TESTS_PASSED", result.stdout)
+            self.assertIn("error_code=42", result.stdout)
+            self.assertNotIn(r"\(runID", result.stdout)
+
+    def test_installed_profile_identity_and_expiration(self):
+        compiler = shutil.which("swiftc")
+        if not compiler:
+            self.skipTest("swiftc unavailable")
+        source = (ROOT / "scripts/templates/livecontainer_refresh_policy.swift").read_text() + r'''
+let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+defer { try? FileManager.default.removeItem(at: directory) }
+let url = directory.appendingPathComponent("profile.fixture")
+let expiry = Date(timeIntervalSince1970: 1900000000)
+let plist: [String: Any] = ["UUID": "TEST-PROFILE-UUID", "ApplicationIdentifierPrefix": ["TESTTEAM"],
+    "Entitlements": ["application-identifier": "TESTTEAM.com.kdt.livecontainer.TESTTEAM"], "ExpirationDate": expiry]
+let xml = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+try (Data([0x30, 0x82, 0x01, 0x02]) + xml + Data([0x01, 0x02])).write(to: url)
+let profile = try LiveContainerHostProfile.read(at: url, expectedBundleID: "com.kdt.livecontainer.TESTTEAM")
+precondition(profile.expiration == expiry && profile.uuid == "TEST-PROFILE-UUID")
+do { _ = try LiveContainerHostProfile.read(at: url, expectedBundleID: "another.app"); fatalError("wrong identity accepted") } catch {}
+try Data("not a provisioning profile".utf8).write(to: url)
+do { _ = try LiveContainerHostProfile.read(at: url, expectedBundleID: "com.kdt.livecontainer.TESTTEAM"); fatalError("invalid profile accepted") } catch {}
+print("INSTALLED_PROFILE_TESTS_PASSED")
+'''
+        with tempfile.TemporaryDirectory() as directory:
+            file = Path(directory) / "main.swift"
+            exe = Path(directory) / "profile-test"
+            file.write_text(source)
+            build = subprocess.run([compiler, "-swift-version", "5", str(file), "-o", str(exe)], text=True, capture_output=True)
+            self.assertEqual(build.returncode, 0, build.stderr)
+            result = subprocess.run([str(exe)], text=True, capture_output=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("INSTALLED_PROFILE_TESTS_PASSED", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -19,6 +19,7 @@ REQUIRED_SCRIPTS = {
 }
 LIVE_CONTAINER_SCRIPT = "patch_livecontainer_autorefresh.py"
 LIVE_CONTAINER_STARTUP_SCRIPT = "patch_embedded_sidestore_startup.py"
+COMBINED_REFRESH_SCRIPT = "patch_combined_refresh_contract.py"
 
 
 class RepositoryTests(unittest.TestCase):
@@ -32,12 +33,13 @@ class RepositoryTests(unittest.TestCase):
         self.assertEqual(
             {path.name for path in SCRIPTS.glob("*.py")},
             REQUIRED_SCRIPTS | {LIVE_CONTAINER_SCRIPT, LIVE_CONTAINER_STARTUP_SCRIPT,
-                                'audit_ipa_signing.py', 'package_livecontainer_combined.py', 'patch_combined_transport.py'},
+                                COMBINED_REFRESH_SCRIPT, 'audit_ipa_signing.py',
+                                'package_livecontainer_combined.py', 'patch_combined_transport.py'},
         )
 
     def test_patch_scripts_parse_and_are_idempotent(self):
         for name in REQUIRED_SCRIPTS | {LIVE_CONTAINER_SCRIPT, LIVE_CONTAINER_STARTUP_SCRIPT,
-                                        "patch_combined_transport.py"}:
+                                        COMBINED_REFRESH_SCRIPT, "patch_combined_transport.py"}:
             path = SCRIPTS / name
             ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         self.assertIn(
@@ -61,6 +63,7 @@ class RepositoryTests(unittest.TestCase):
         self.assertNotIn("build-v29-coredevice-self-refresh.yml", workflow)
         live_workflow = (ROOT / ".github/workflows/livecontainer-build.yml").read_text(encoding="utf-8")
         self.assertIn("builder/scripts/" + LIVE_CONTAINER_STARTUP_SCRIPT, live_workflow)
+        self.assertIn("builder/scripts/" + COMBINED_REFRESH_SCRIPT, live_workflow)
 
     def test_upstream_ipsec_anchor_preserves_original_punctuation(self):
         source = (SCRIPTS / "patch_sidestore_integration.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Root cause
Failed run `34118208566` stopped during generated Swift parsing: changing the Python scheduler string to `rf'''` preserved escaped quotes inside Swift interpolation. The same generator also emitted literal `\\(` diagnostic values.

## Fixes
- Store scheduler/policy/settings/AlarmKit as ordinary Swift templates; parse generated sources before expensive Rust/iOS builds.
- Resolve BG task IDs from the *installed* `BGTaskSchedulerPermittedIdentifiers`; support signers that leave IDs unchanged or rewrite them. Preserve upstream values, add both `processing` and `fetch`. No first manual refresh is needed just to repair an assumed bundle-prefix rewrite.
- Use combined intent metadata action/type; turn nil XPC setup into explicit errors and register the continuation before dispatching remote work.
- Main-actor single-run coordination, bounded event-driven retries, no-op path, disabled-schedule guard and exactly-once BG completion. Expiration cannot become late verified success.
- Pre-scheduled local deadline warning plus optional, availability-isolated AlarmKit. Permission denial does not disable refresh. No polling/keepalive.
- Align embedded manifest/handoff IDs to the host run and require results for every expected app.
- Inspect the installed host profile on relaunch instead of trusting the database's optimistic expiration. A pending handoff or missing result is not success. Profile parsing is metadata inspection, not independent CMS verification.
- Retain existing startup, CoreDevice/idevice/jktcp patches, all extensions, combined packaging and deployment targets. Check actual packaged AlarmKit load commands.

## Validation
Local Swift parsing, policy execution, scheduler execution against OS doubles, profile fixtures, incomplete-result/failed/duplicate-trigger tests and patch idempotence pass: 9 passed, 1 pinned-source test skipped locally. The full repository suite and pinned-source test run in CI. Device transport, Apple-account signing, notification delivery and battery comparison are **not** proven by these tests.

The workflow adds a push trigger scoped only to this fix branch to run the requested combined build; main retains manual dispatch. No public release is published.

## Required device acceptance after CI
Install over the existing same-team combined app without deleting data. Confirm embedded startup, manual refresh, installed host validity after relaunch, registered BG IDs, permitted notifications and a real scheduled LocalDevVPN-only refresh. No VPN Super-free or lower-battery claim before that evidence.