### PR TITLE
Make refresh history selection and deletion safe during live updates

### DIFF
--- a/scripts/templates/livecontainer_refresh_settings.swift
+++ b/scripts/templates/livecontainer_refresh_settings.swift
@@ -1,10 +1,77 @@
 import SwiftUI
+import Foundation
 
+// LC_REFRESH_HISTORY_STORE_V1_BEGIN
+/// Stable row identity is separate from display order: refresh events can be
+/// prepended while the user is selecting or swiping an older entry.
+struct LiveContainerRefreshHistoryEntry: Identifiable, Equatable {
+    let id: String
+    let values: [String: String]
+}
+
+/// The host scheduler writes history on MainActor too. These synchronous
+/// read/modify/write operations cannot interleave with a host history append.
+/// No network, timer, refresh request, or health-state mutation is involved.
+@MainActor
+enum LiveContainerRefreshHistoryStore {
+    static let key = "liveContainerAutoRefreshHistory"
+    static let didChange = Notification.Name("LiveContainerAutoRefreshHistoryChanged")
+
+    private static func identified(_ entries: [[String: String]]) -> [[String: String]] {
+        var used = Set<String>()
+        return entries.map { entry in
+            var value = entry
+            if let id = value["id"], !id.isEmpty, used.insert(id).inserted {
+                return value
+            }
+            var id = UUID().uuidString
+            while !used.insert(id).inserted { id = UUID().uuidString }
+            value["id"] = id
+            return value
+        }
+    }
+
+    private static func rows(_ entries: [[String: String]]) -> [LiveContainerRefreshHistoryEntry] {
+        entries.compactMap { value in
+            guard let id = value["id"] else { return nil }
+            return LiveContainerRefreshHistoryEntry(id: id, values: value)
+        }
+    }
+
+    static func entries(in defaults: UserDefaults) -> [LiveContainerRefreshHistoryEntry] {
+        let previous = defaults.array(forKey: key) as? [[String: String]] ?? []
+        let current = identified(previous)
+        // Legacy and newly recorded events gain a persistent identity only
+        // when this screen needs it. An unchanged read performs no write.
+        if current != previous { defaults.set(current, forKey: key) }
+        return rows(current)
+    }
+
+    static func delete(ids: Set<String>, in defaults: UserDefaults) {
+        guard !ids.isEmpty else { return }
+        // Never write the view's possibly stale array back over newer events.
+        let previous = defaults.array(forKey: key) as? [[String: String]] ?? []
+        let current = identified(previous).filter { !ids.contains($0["id"] ?? "") }
+        guard current != previous else { return }
+        defaults.set(current, forKey: key)
+        NotificationCenter.default.post(name: didChange, object: nil)
+    }
+
+    static func clear(in defaults: UserDefaults) {
+        guard defaults.object(forKey: key) != nil else { return }
+        defaults.removeObject(forKey: key)
+        NotificationCenter.default.post(name: didChange, object: nil)
+    }
+}
+// LC_REFRESH_HISTORY_STORE_V1_END
+
+@MainActor
 struct LCEmbeddedSideStoreRefreshView: View {
     private let defaults = UserDefaults(suiteName: "group.com.SideStore.SideStore") ?? .standard
-    @State private var history: [[String: String]] = []
+    @Environment(\.layoutDirection) private var layoutDirection
+    @State private var history: [LiveContainerRefreshHistoryEntry] = []
     @State private var isSelectingHistory = false
-    @State private var selectedHistoryIndexes: Set<Int> = []
+    @State private var selectedHistoryIDs: Set<String> = []
     @State private var showClearHistoryConfirmation = false
     @AppStorage("liveContainerAutoRefreshEnabled", store: UserDefaults(suiteName: "group.com.SideStore.SideStore")) private var enabled = false
     @AppStorage("liveContainerAutoRefreshFrequency", store: UserDefaults(suiteName: "group.com.SideStore.SideStore")) private var frequency = "interval"
@@ -76,75 +143,97 @@ struct LCEmbeddedSideStoreRefreshView: View {
                     }
                 }
             }
-            Section {
-                if !history.isEmpty {
-                    HStack {
-                        Button(isSelectingHistory ? "Done" : "Select") {
-                            withAnimation {
-                                isSelectingHistory.toggle()
-                                if !isSelectingHistory { selectedHistoryIndexes.removeAll() }
-                            }
-                        }
-                        Spacer()
-                        if isSelectingHistory && !selectedHistoryIndexes.isEmpty {
-                            Button("Delete Selected", role: .destructive) {
-                                deleteSelectedHistory()
-                            }
-                        }
-                        Button("Clear All", role: .destructive) {
-                            showClearHistoryConfirmation = true
-                        }
-                    }
-                }
-
-                if history.isEmpty {
-                    Text("No refreshes recorded").foregroundColor(.secondary)
-                }
-
-                ForEach(Array(history.prefix(20).enumerated()), id: \.offset) { index, entry in
-                    HStack(alignment: .top, spacing: 10) {
-                        if isSelectingHistory {
-                            Image(systemName: selectedHistoryIndexes.contains(index) ? "checkmark.circle.fill" : "circle")
-                                .foregroundColor(selectedHistoryIndexes.contains(index) ? .accentColor : .secondary)
-                                .font(.title3)
-                        }
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("\(entry["source"]?.capitalized ?? "Unknown") - \(entry["result"]?.capitalized ?? "Unknown")")
-                            Text(entry["date"] ?? "").font(.caption).foregroundColor(.secondary)
-                            if let detail = entry["detail"], !detail.isEmpty { Text(detail).font(.caption2).foregroundColor(.secondary) }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        guard isSelectingHistory else { return }
-                        if selectedHistoryIndexes.contains(index) {
-                            selectedHistoryIndexes.remove(index)
-                        } else {
-                            selectedHistoryIndexes.insert(index)
-                        }
-                    }
-                    .swipeActions(edge: .leading, allowsFullSwipe: true) {
-                        if !isSelectingHistory {
-                            Button(role: .destructive) {
-                                deleteHistoryEntry(at: index)
-                            } label: {
-                                Label("Delete", systemImage: "trash")
-                            }
-                        }
-                    }
-                }
-            } header: {
-                Text("History")
-            }
+            historySection
         }
         .navigationTitle("SideStore refresh")
         .onAppear { reloadHistory() }
-        .onReceive(NotificationCenter.default.publisher(for: Notification.Name("LiveContainerAutoRefreshHistoryChanged")).receive(on: RunLoop.main)) { _ in reloadHistory() }
+        .onReceive(NotificationCenter.default.publisher(for: LiveContainerRefreshHistoryStore.didChange).receive(on: RunLoop.main)) { _ in reloadHistory() }
         .confirmationDialog("Clear all refresh history?", isPresented: $showClearHistoryConfirmation, titleVisibility: .visible) {
             Button("Clear All", role: .destructive) { clearHistory() }
             Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This deletes history entries only. Refresh settings and the current signing status are not changed.")
         }
+    }
+
+    private var historySection: some View {
+        Section {
+            if !history.isEmpty {
+                HStack {
+                    Button(isSelectingHistory ? "Done" : "Select") {
+                        withAnimation {
+                            isSelectingHistory.toggle()
+                            if !isSelectingHistory { selectedHistoryIDs.removeAll() }
+                        }
+                    }
+                    Spacer()
+                    Button("Clear All", role: .destructive) { showClearHistoryConfirmation = true }
+                }
+                // Keep buttons independently tappable inside the same Form row.
+                .buttonStyle(.borderless)
+                if isSelectingHistory {
+                    HStack {
+                        Text("\(selectedHistoryIDs.count) selected").foregroundColor(.secondary)
+                        Spacer()
+                        Button("Delete Selected", role: .destructive, action: deleteSelectedHistory)
+                            .disabled(selectedHistoryIDs.isEmpty)
+                    }
+                    .buttonStyle(.borderless)
+                }
+            }
+            if history.isEmpty {
+                Text("No refreshes recorded").foregroundColor(.secondary)
+            }
+            // The scheduler already caps retention at 50. Do not hide the older
+            // 30 entries from selection while Clear All still deletes them.
+            ForEach(history) { entry in historyRow(entry) }
+        } header: {
+            Text("History")
+        } footer: {
+            Text("Swipe right to reveal Delete, or use Select to delete several entries. Deleting history does not change refresh status or scheduled tasks.")
+        }
+    }
+
+    @ViewBuilder
+    private func historyRow(_ entry: LiveContainerRefreshHistoryEntry) -> some View {
+        if isSelectingHistory {
+            Button { toggleSelection(entry.id) } label: { historyContent(entry) }
+                .buttonStyle(.plain)
+                .accessibilityValue(selectedHistoryIDs.contains(entry.id) ? "Selected" : "Not selected")
+                .accessibilityAddTraits(selectedHistoryIDs.contains(entry.id) ? [.isSelected] : [])
+        } else {
+            historyContent(entry)
+                // Preserve a physical rightward gesture in LTR and RTL layouts.
+                .swipeActions(edge: layoutDirection == .rightToLeft ? .trailing : .leading, allowsFullSwipe: false) {
+                    Button(role: .destructive) { deleteHistoryEntry(id: entry.id) } label: {
+                        Label("Delete", systemImage: "trash")
+                    }
+                }
+                .accessibilityAction(named: Text("Delete")) { deleteHistoryEntry(id: entry.id) }
+        }
+    }
+
+    private func historyContent(_ entry: LiveContainerRefreshHistoryEntry) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            if isSelectingHistory {
+                Image(systemName: selectedHistoryIDs.contains(entry.id) ? "checkmark.circle.fill" : "circle")
+                    .foregroundColor(selectedHistoryIDs.contains(entry.id) ? .accentColor : .secondary)
+                    .font(.title3)
+                    .accessibilityHidden(true)
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(entry.values["source"]?.capitalized ?? "Unknown") - \(entry.values["result"]?.capitalized ?? "Unknown")")
+                Text(entry.values["date"] ?? "").font(.caption).foregroundColor(.secondary)
+                if let detail = entry.values["detail"], !detail.isEmpty { Text(detail).font(.caption2).foregroundColor(.secondary) }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .contentShape(Rectangle())
+    }
+
+    private func toggleSelection(_ id: String) {
+        if selectedHistoryIDs.contains(id) { selectedHistoryIDs.remove(id) }
+        else { selectedHistoryIDs.insert(id) }
     }
 
     private func notifyScheduleChanged() {
@@ -155,38 +244,34 @@ struct LCEmbeddedSideStoreRefreshView: View {
         NotificationCenter.default.post(name: Notification.Name("LiveContainerAutoRefreshRunNow"), object: nil)
     }
 
-    private func persistHistory() {
-        defaults.set(history, forKey: "liveContainerAutoRefreshHistory")
-        NotificationCenter.default.post(name: Notification.Name("LiveContainerAutoRefreshHistoryChanged"), object: nil)
-    }
-
-    private func deleteHistoryEntry(at index: Int) {
-        guard history.indices.contains(index) else { return }
-        history.remove(at: index)
-        selectedHistoryIndexes.removeAll()
-        persistHistory()
+    private func deleteHistoryEntry(id: String) {
+        withAnimation {
+            LiveContainerRefreshHistoryStore.delete(ids: [id], in: defaults)
+            reloadHistory()
+        }
     }
 
     private func deleteSelectedHistory() {
-        guard !selectedHistoryIndexes.isEmpty else { return }
-        for index in selectedHistoryIndexes.sorted(by: >) where history.indices.contains(index) {
-            history.remove(at: index)
+        withAnimation {
+            LiveContainerRefreshHistoryStore.delete(ids: selectedHistoryIDs, in: defaults)
+            selectedHistoryIDs.removeAll()
+            isSelectingHistory = false
+            reloadHistory()
         }
-        selectedHistoryIndexes.removeAll()
-        isSelectingHistory = false
-        persistHistory()
     }
 
     private func clearHistory() {
-        history.removeAll()
-        selectedHistoryIndexes.removeAll()
-        isSelectingHistory = false
-        defaults.removeObject(forKey: "liveContainerAutoRefreshHistory")
-        NotificationCenter.default.post(name: Notification.Name("LiveContainerAutoRefreshHistoryChanged"), object: nil)
+        withAnimation {
+            LiveContainerRefreshHistoryStore.clear(in: defaults)
+            selectedHistoryIDs.removeAll()
+            isSelectingHistory = false
+            reloadHistory()
+        }
     }
 
     private func reloadHistory() {
-        history = defaults.array(forKey: "liveContainerAutoRefreshHistory") as? [[String: String]] ?? []
-        selectedHistoryIndexes = selectedHistoryIndexes.filter { history.indices.contains($0) }
+        history = LiveContainerRefreshHistoryStore.entries(in: defaults)
+        selectedHistoryIDs.formIntersection(Set(history.map(\.id)))
+        if history.isEmpty { isSelectingHistory = false }
     }
 }

--- a/tests/test_livecontainer_history.py
+++ b/tests/test_livecontainer_history.py
@@ -11,12 +11,19 @@ TEMPLATE = ROOT / "scripts/templates/livecontainer_refresh_settings.swift"
 HARNESS = r'''
 final class CountingDefaults: UserDefaults {
     var historyWrites = 0
+    private var mutationDepth = 0
     override func set(_ value: Any?, forKey defaultName: String) {
-        if defaultName == "liveContainerAutoRefreshHistory" { historyWrites += 1 }
+        // Apple Foundation can implement removeObject by calling set(nil).
+        // Count the store's outer API mutation once, not Foundation re-entry.
+        if mutationDepth == 0 && defaultName == "liveContainerAutoRefreshHistory" { historyWrites += 1 }
+        mutationDepth += 1
+        defer { mutationDepth -= 1 }
         super.set(value, forKey: defaultName)
     }
     override func removeObject(forKey defaultName: String) {
-        if defaultName == "liveContainerAutoRefreshHistory" { historyWrites += 1 }
+        if mutationDepth == 0 && defaultName == "liveContainerAutoRefreshHistory" { historyWrites += 1 }
+        mutationDepth += 1
+        defer { mutationDepth -= 1 }
         super.removeObject(forKey: defaultName)
     }
 }
@@ -109,9 +116,9 @@ struct HistoryTests {
             for (key, expected) in baseline {
                 precondition(NSDictionary(dictionary: [key: defaults.object(forKey: key)!]).isEqual(to: [key: expected]))
             }
-            precondition(defaults.historyWrites == 2)
+            precondition(defaults.historyWrites == 2, "Expected two outer history mutations, got \(defaults.historyWrites)")
             Store.clear(in: defaults)
-            precondition(defaults.historyWrites == 2)
+            precondition(defaults.historyWrites == 2, "Expected two outer history mutations, got \(defaults.historyWrites)")
             appendSchedulerEvent("after-clear")
             precondition(Store.entries(in: defaults).first?.values["detail"] == "after-clear")
         case "retention_and_reorder":

--- a/tests/test_livecontainer_history.py
+++ b/tests/test_livecontainer_history.py
@@ -1,0 +1,218 @@
+"""Execute the shipped Foundation-only history store, not a Python reimplementation."""
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "scripts/templates/livecontainer_refresh_settings.swift"
+
+HARNESS = r'''
+final class CountingDefaults: UserDefaults {
+    var historyWrites = 0
+    override func set(_ value: Any?, forKey defaultName: String) {
+        if defaultName == "liveContainerAutoRefreshHistory" { historyWrites += 1 }
+        super.set(value, forKey: defaultName)
+    }
+    override func removeObject(forKey defaultName: String) {
+        if defaultName == "liveContainerAutoRefreshHistory" { historyWrites += 1 }
+        super.removeObject(forKey: defaultName)
+    }
+}
+
+@main
+struct HistoryTests {
+    @MainActor
+    static func main() {
+        let suite = "LiveContainerHistoryTests." + UUID().uuidString
+        let defaults = CountingDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        typealias Store = LiveContainerRefreshHistoryStore
+        let key = Store.key
+        func row(_ id: String, _ result: String = "failure") -> [String: String] {
+            ["id": id, "date": "2026-09-07T12:00:00Z", "source": "manual", "result": result, "detail": "test"]
+        }
+        func seed(_ values: [[String: String]]) {
+            defaults.set(values, forKey: key)
+            defaults.historyWrites = 0
+        }
+        func ids() -> [String] { Store.entries(in: defaults).map(\.id) }
+        // This is the real scheduler's legacy append shape. It deliberately has
+        // no UI ID yet; normalization must not confuse equal-looking events.
+        func appendSchedulerEvent(_ detail: String) {
+            var current = defaults.array(forKey: key) as? [[String: String]] ?? []
+            current.insert(["date": "2026-09-07T12:00:00Z", "source": "background", "result": "failure", "detail": detail], at: 0)
+            defaults.set(Array(current.prefix(50)), forKey: key)
+        }
+        let scenario = CommandLine.arguments[1]
+        switch scenario {
+        case "empty_noop":
+            precondition(Store.entries(in: defaults).isEmpty)
+            Store.delete(ids: [], in: defaults)
+            Store.delete(ids: ["missing"], in: defaults)
+            Store.clear(in: defaults)
+            precondition(defaults.historyWrites == 0)
+        case "migration":
+            let legacy = ["date": "same", "source": "manual", "result": "failure", "extra": "preserved"]
+            seed([legacy, legacy])
+            let first = Store.entries(in: defaults)
+            precondition(first.count == 2 && first[0].id != first[1].id)
+            precondition(first.allSatisfy { $0.values["extra"] == "preserved" })
+            precondition(defaults.historyWrites == 1)
+            precondition(Store.entries(in: defaults) == first)
+            let reopened = UserDefaults(suiteName: suite)!
+            precondition(Store.entries(in: reopened) == first)
+            precondition(defaults.historyWrites == 1)
+        case "duplicate_ids":
+            seed([row("a"), row("a"), row(""), ["result": "failure"]])
+            let first = ids()
+            precondition(first.count == 4 && Set(first).count == 4 && first[0] == "a")
+            precondition(!first.contains(""))
+            Store.delete(ids: [first[1]], in: defaults)
+            precondition(ids() == [first[0], first[2], first[3]])
+        case "selection_after_insert":
+            seed([row("a"), row("b"), row("c")])
+            let selected = Set(Store.entries(in: defaults).filter { $0.id != "b" }.map(\.id))
+            appendSchedulerEvent("new-event")
+            defaults.historyWrites = 0
+            Store.delete(ids: selected, in: defaults)
+            let current = Store.entries(in: defaults)
+            precondition(current.count == 2 && current[0].values["detail"] == "new-event" && current[1].id == "b")
+            precondition(defaults.historyWrites == 1)
+        case "stale_swipe":
+            seed([row("a"), row("b")])
+            let swiped = Store.entries(in: defaults)[1].id
+            appendSchedulerEvent("new-event")
+            Store.delete(ids: [swiped], in: defaults)
+            let current = Store.entries(in: defaults)
+            precondition(current.count == 2 && current[0].values["detail"] == "new-event" && current[1].id == "a")
+            defaults.historyWrites = 0
+            Store.delete(ids: [swiped], in: defaults) // Duplicate callback is harmless.
+            precondition(defaults.historyWrites == 0)
+        case "clear_preserves_refresh":
+            let baseline: [String: Any] = [
+                "liveContainerAutoRefreshEnabled": true,
+                "liveContainerAutoRefreshLastResult": "failure",
+                "liveContainerAutoRefreshHealthState": "HOST_REFRESH_FAILED",
+                "liveContainerAutoRefreshLastError": "pairing invalid",
+                "liveContainerAutoRefreshTargetDeadline": Date(timeIntervalSince1970: 5000),
+                "liveContainerAutoRefreshNextRetryAt": Date(timeIntervalSince1970: 4000),
+                "liveContainerAutoRefreshHostHandoff": true,
+                "liveContainerAutoRefreshVerification": ["run_id": "keep-me"]
+            ]
+            for (key, value) in baseline { defaults.set(value, forKey: key) }
+            seed([row("a"), row("b")])
+            Store.delete(ids: ["b"], in: defaults)
+            Store.clear(in: defaults)
+            precondition(defaults.object(forKey: key) == nil)
+            for (key, expected) in baseline {
+                precondition(NSDictionary(dictionary: [key: defaults.object(forKey: key)!]).isEqual(to: [key: expected]))
+            }
+            precondition(defaults.historyWrites == 2)
+            Store.clear(in: defaults)
+            precondition(defaults.historyWrites == 2)
+            appendSchedulerEvent("after-clear")
+            precondition(Store.entries(in: defaults).first?.values["detail"] == "after-clear")
+        case "retention_and_reorder":
+            seed((0..<50).map { row(String($0)) })
+            precondition(Store.entries(in: defaults).count == 50)
+            let selected = Set(["49", "10"])
+            appendSchedulerEvent("newest") // Scheduler evicts 49, not 10.
+            let remainingSelection = selected.intersection(Set(ids()))
+            precondition(remainingSelection == ["10"])
+            Store.delete(ids: selected, in: defaults)
+            precondition(ids().count == 49 && !ids().contains("10") && ids().contains("48"))
+            seed([row("c"), row("a"), row("b")])
+            Store.delete(ids: ["a"], in: defaults)
+            precondition(ids() == ["c", "b"])
+        case "read_budget":
+            seed((0..<50).map { row(String($0)) })
+            for _ in 0..<100 { precondition(Store.entries(in: defaults).count == 50) }
+            Store.delete(ids: [], in: defaults)
+            Store.delete(ids: ["absent"], in: defaults)
+            precondition(defaults.historyWrites == 0)
+        default:
+            fatalError("Unknown test scenario: \(scenario)")
+        }
+        print("HISTORY_TEST_PASSED=\(scenario)")
+    }
+}
+'''
+
+
+class HistorySourceTests(unittest.TestCase):
+    def test_ui_uses_stable_ids_and_latest_store(self):
+        text = TEMPLATE.read_text(encoding="utf-8")
+        self.assertIn("ForEach(history)", text)
+        self.assertIn("selectedHistoryIDs: Set<String>", text)
+        self.assertIn("selectedHistoryIDs.formIntersection", text)
+        self.assertNotIn("selectedHistoryIndexes", text)
+        self.assertNotIn("history.prefix(20)", text)
+        self.assertNotIn("history.remove(at:", text)
+        self.assertNotIn("defaults.set(history", text)
+        self.assertIn(".buttonStyle(.borderless)", text)
+        self.assertIn(".disabled(selectedHistoryIDs.isEmpty)", text)
+        self.assertIn(".confirmationDialog", text)
+        self.assertIn("layoutDirection == .rightToLeft ? .trailing : .leading", text)
+        self.assertIn("allowsFullSwipe: false", text)
+        self.assertIn(".accessibilityAction(named: Text(\"Delete\"))", text)
+
+    def test_shipped_view_parses(self):
+        compiler = shutil.which("swiftc")
+        if not compiler:
+            self.skipTest("swiftc unavailable; native UI parse not verified")
+        result = subprocess.run([compiler, "-frontend", "-parse", str(TEMPLATE)], capture_output=True, text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+class HistoryExecutionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        compiler = shutil.which("swiftc")
+        if not compiler:
+            raise unittest.SkipTest("swiftc unavailable; real history store not executed")
+        cls.temp = tempfile.TemporaryDirectory(prefix="lc-history-tests-")
+        cls.addClassCleanup(cls.temp.cleanup)
+        source = TEMPLATE.read_text(encoding="utf-8")
+        start = source.index("// LC_REFRESH_HISTORY_STORE_V1_BEGIN")
+        end = source.index("// LC_REFRESH_HISTORY_STORE_V1_END")
+        file = Path(cls.temp.name) / "HistoryTests.swift"
+        file.write_text("import Foundation\n" + source[start:end] + HARNESS, encoding="utf-8")
+        cls.executable = Path(cls.temp.name) / "history-test"
+        result = subprocess.run([compiler, "-swift-version", "5", "-parse-as-library", str(file), "-o", str(cls.executable)], capture_output=True, text=True, timeout=90)
+        if result.returncode:
+            raise AssertionError(result.stderr)
+
+    def check_scenario(self, scenario):
+        result = subprocess.run([str(self.executable), scenario], capture_output=True, text=True, timeout=20)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("HISTORY_TEST_PASSED=" + scenario, result.stdout)
+
+    def test_empty_and_missing_actions_are_noop(self):
+        self.check_scenario("empty_noop")
+
+    def test_legacy_identity_migration_survives_reopen(self):
+        self.check_scenario("migration")
+
+    def test_duplicate_ids_remain_individually_deletable(self):
+        self.check_scenario("duplicate_ids")
+
+    def test_selection_remains_correct_after_scheduler_insert(self):
+        self.check_scenario("selection_after_insert")
+
+    def test_stale_swipe_preserves_new_events(self):
+        self.check_scenario("stale_swipe")
+
+    def test_deletion_preserves_refresh_and_signing_state(self):
+        self.check_scenario("clear_preserves_refresh")
+
+    def test_retention_and_reordering_cannot_retarget_selection(self):
+        self.check_scenario("retention_and_reorder")
+
+    def test_repeated_reads_do_not_write(self):
+        self.check_scenario("read_budget")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Review findings and fixes
The history UI selected/deleted array indexes and persisted its local snapshot. A new scheduler event could shift a selection onto a different row or be overwritten by a stale deletion. This change uses persistent row IDs and synchronous MainActor mutations of the latest stored history.

- Keep Clear All with explicit confirmation and Cancel.
- Rightward swipe reveals Delete in both LTR/RTL; no accidental full-swipe deletion.
- Select/Done, selected count, and Delete Selected; disabled when nothing is selected.
- Stable row identity survives new events, reordering, duplicate-looking legacy records and retention eviction.
- Independently tappable Form controls and accessible row selection/deletion.
- Display all retained history (the scheduler already caps it at 50), not only the newest 20.
- Delete history only: do not clear errors, health, signing, pending host handoff, verification results, retry state or schedules.
- No polling or network work. Stable reads perform zero writes; identity migration happens only when this screen needs it.

## Validation
10 new local tests passed, including real Swift execution of the exact shipped Foundation-only store, UserDefaults persistence/write budgets, stale swipe, selection during insertion, duplicate IDs, retention, clear-and-append and preservation of operational state. The SwiftUI template parses locally; actual iOS type-checking and the full repository suite run in the existing combined CI build triggered by this commit. UI gestures on a real iPhone remain unverified.

Only the settings template and a regression-test file change. No transport, signing, scheduler engine, deployment target, dependencies or public release changes.