### PR TITLE
Ship combined refresh runtime, guest controls, and v2.0.0 documentation

### DIFF
--- a/.github/workflows/livecontainer-build.yml
+++ b/.github/workflows/livecontainer-build.yml
@@ -98,6 +98,10 @@ jobs:
             python3 builder/scripts/patch_livecontainer_autorefresh.py work/LiveContainer
             python3 builder/scripts/patch_embedded_sidestore_startup.py work/LiveContainer work/EmbeddedSideStore
             python3 builder/scripts/patch_embedded_sidestore_startup.py work/LiveContainer work/EmbeddedSideStore
+            python3 builder/scripts/patch_guest_return.py work/LiveContainer
+            python3 builder/scripts/patch_guest_return.py work/LiveContainer
+            swiftc -frontend -parse work/LiveContainer/MultitaskSupport/MultitaskAppWindow.swift
+            swiftc -frontend -parse work/LiveContainer/MultitaskSupport/MultitaskDockView.swift
             python3 - <<'PY'
           import importlib.util
           from pathlib import Path

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,12 @@ official LocalDevVPN -> Lockdown -> CoreDeviceProxy -> CDTunnel -> RSD
 
 The highest-value contribution is **real-device compatibility testing** across additional iPhone/iPad models, iOS versions, and Wi-Fi network ranges.
 
-The current proof device has completed manual CoreDevice refresh and a full PC-free scheduled refresh. Community testing should now focus on how broadly that result reproduces.
+The standalone SideStore proof device has completed manual CoreDevice refresh and a full PC-free scheduled refresh. Combined LiveContainer results are tracked separately; do not infer combined host replacement or unattended refresh from the standalone proof.
 
 Useful reports include:
 
 - iPhone/iPad model
+- Standalone or combined variant and installed build/version
 - iOS version
 - Wi-Fi IPv4 network family (`10.x`, `192.168.x`, `172.16-31.x`, or other; exact addresses are not required)
 - whether official LocalDevVPN remained connected
@@ -56,7 +57,7 @@ Be precise about proof level:
 - Neither marker alone proves that iOS executed the task.
 - A real scheduled run is established by `TRIGGER`, operation markers, and a successful completion/result.
 
-The current proof device has satisfied the full PC-free scheduled-refresh condition documented in [`docs/VERIFICATION.md`](docs/VERIFICATION.md). New compatibility claims should include equivalent non-sensitive evidence where practical.
+The standalone proof device has satisfied the PC-free scheduled-refresh condition documented in [`docs/VERIFICATION.md`](docs/VERIFICATION.md). New variant or compatibility claims need their own equivalent non-sensitive evidence.
 
 ## Security and privacy
 

--- a/README.md
+++ b/README.md
@@ -1,186 +1,157 @@
-# SideStore Auto-Refresh: On-Device, No PC at Runtime
+# LiveContainer + SideStore Auto-Refresh
 
-[![Build Current SideStore](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/workflows/build-current.yml/badge.svg)](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/workflows/build-current.yml)
+[![Combined Build](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/workflows/livecontainer-build.yml/badge.svg)](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/workflows/livecontainer-build.yml)
 [![Release](https://img.shields.io/github/v/release/NRG-Wardog/sidestore-auto-refresh)](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Keep **SideStore and up to two personally signed iOS apps refreshed directly from the iPhone** with a Free Apple Account, the official App Store **LocalDevVPN**, and Apple's CoreDevice stack.
+LiveContainer with embedded SideStore, native refresh scheduling, and an on-device
+**LocalDevVPN + CoreDevice** refresh path for a **Free Apple Account / Personal Team**.
 
-The intended refresh runtime does **not** require a PC, USB connection, relay server, jailbreak, paid Apple Developer account, custom NetworkExtension, or custom VPN app.
-
-> **Current proof status:** same-device CoreDevice transport, IPA staging/install, manual `Refresh All`, native iOS background-task registration/scheduling, and final PC-free device proof are verified. See [`docs/VERIFICATION.md`](docs/VERIFICATION.md) for exact evidence, build hashes, device markers, and reproduction notes.
-
-Additional device/iOS/network compatibility reports are welcome. See [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md) and [Issue #1](https://github.com/NRG-Wardog/sidestore-auto-refresh/issues/1).
+The intended refresh runtime needs **no PC, USB, external relay, jailbreak, paid
+developer membership, custom NetworkExtension, or modified VPN app**. Initial
+signing and installation still require a compatible installer.
 
 ## Download
 
-### Prebuilt IPA: recommended
+### LiveContainer + embedded SideStore: v2.0.0
 
-**[Download SideStore CoreDevice Auto-Refresh v1.0.2](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/download/v1.0.2/SideStore-CoreDevice-AutoRefresh-v1.0.2.ipa)**
+**[Download the combined IPA](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/download/v2.0.0/LiveContainer-SideStore-AutoRefresh-v2.0.0.ipa)**
 
-Latest release: **[v1.0.2](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/latest)**
+[Latest stable release](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/latest)
+| [Release notes](docs/RELEASE_NOTES_v2.0.0.md)
+| [Checksums](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/download/v2.0.0/SHA256SUMS.txt)
 
-SHA-256:
+- Builder: `f20e14e43b4048c5b5791e7d4b0bb6e32930c10a`
+- [Verified build 34238644076](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/runs/34238644076)
+- 76 CI tests, 2 skipped; both Release builds and combined-package checks passed.
+- SHA-256: `1c29648ee99abd67cd6244d0405f2ab9df0beca92adb4c35bed5c133eb7d974e`
 
-```text
-120BA06C51D4D235743451B065968DC94F7C7374CACB955827860254E01B5A76
-```
+Sign with your own account. **Update over the existing same-team,
+same-identifier LiveContainer installation; do not delete it first.** Back up
+important guest data. Standalone-to-combined data migration is not provided.
 
-Release provenance:
+### Standalone SideStore: v1.0.2
 
-```text
-builder_commit=f33487d473e09620493d2a8d82e8e37c9bdef32b
-GitHub Actions run=34045788967
-verification=PASS
-```
+**[Download standalone SideStore](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/download/v1.0.2/SideStore-CoreDevice-AutoRefresh-v1.0.2.ipa)**
+| [Standalone release notes](docs/RELEASE_NOTES_v1.0.2.md)
 
-The release includes the IPA and the release notes for integrity and build-provenance verification.
+This separate variant keeps SideStore and up to two other personally signed
+standalone apps within the normal free-account installed-app limit. It is not
+bundled into the v2.0.0 release. Update it over the matching existing SideStore
+installation, not over LiveContainer.
 
-> Install the IPA **over your existing SideStore installation**. Do not delete SideStore first; replacing it preserves pairing data, account state, and the local database used by the refresh path.
+## What is included
 
-Prefer to inspect and reproduce the build yourself? See [Build it yourself](#build-it-yourself).
+- **Combined upstream packaging:** embedded SideStore and dependencies, widget,
+  LiveProcess, ShareExtension, LaunchAppExtension, and required intent/group metadata.
+- **LocalDevVPN/CoreDevice transport:** service TLS, CDTunnel, RSD, AFC staging,
+  installation routing, transfer reliability, and explicit transport diagnostics.
+- **Native-first automation:** six-hour, daily, and weekly schedules, background
+  processing, a lightweight watchdog, launch/resume recovery, and bounded retry.
+- **Deadline protection:** optional AlarmKit safety alerts on iOS 26.1+ when
+  authorized, with local-notification fallback. Shortcuts are optional.
+- **Refresh status:** manual/scheduled history, deletion controls, actionable
+  failures, run-correlated verification results, and bounded console logs.
+- **Embedded startup/authentication fixes:** host identity hooks, safe database
+  retries, shared-Keychain migration, and reusable-session-aware preflight.
+- **Guest Return controls:** draggable button, collapsible edge tab, global
+  visibility setting, and automatic hiding in windowed multitasking.
 
-### LiveContainer combined variant
+## Quick start: combined build
 
-**[Download v2.0.0 preview](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/tag/v2.0.0)**
-contains only the combined LiveContainer IPA. Standalone SideStore remains in
-its separate v1.0.2 release. See the [release notes](docs/RELEASE_NOTES_v2.0.0.md)
-before testing.
+1. Sign/install the combined IPA using a compatible installer and your Apple account.
+2. Enable Developer Mode and provide a valid Lockdown pairing file.
+3. Configure official App Store LocalDevVPN as described below.
+4. Open LiveContainer, then embedded SideStore, and sign in.
+5. Perform a manual refresh first; inspect its result and signing expiration.
+6. In LiveContainer's refresh settings, enable automation and choose a schedule.
+7. Allow notifications and Background App Refresh for the protections you want.
+8. Keep Wi-Fi and the correctly configured LocalDevVPN route available.
 
-The separate LiveContainer + embedded SideStore build uses the pinned upstream
-combined packaging process. Package verification passed, but successful signing
-and installation of this variant remain unverified.
+For standalone v1.0.2, use SideStore > Settings > Refreshing Apps > Refresh Schedule.
 
-The combined package has five App ID registration targets before identifier
-reuse; this is separate from the free account's installed-app limit. Deleting
-App IDs does not necessarily restore registration capacity immediately.
+**In the combined build, selected time is a target deadline, not an exact wake
+time.** Background requests are scheduled earlier, subject to eligibility and
+retry timing. iOS can delay or omit execution. Daily or six-hour schedules provide
+more safety margin than weekly scheduling near a seven-day signing expiration.
 
-## Quick start
-
-1. Download the prebuilt IPA above.
-2. Install it **over your existing SideStore** using your development installer.
-3. Open SideStore once.
-4. Configure the official **LocalDevVPN** for the iPhone's current Wi-Fi subnet using the required setup below.
-5. Keep the official **LocalDevVPN** connected.
-6. Keep **Developer Mode** enabled.
-7. Enable **Background App Refresh** in iOS.
-8. Keep the device on **Wi-Fi**.
-9. In SideStore, open **Settings → Refreshing Apps → Refresh Schedule**.
-10. Choose Every Six Hours, Daily, or Weekly.
-
-Weekly scheduling leaves little safety margin before free-account apps expire, and iOS may delay background execution. Six-hour or daily scheduling is safer.
-
-> iOS decides when a `BGProcessingTask` actually runs. A selected time is an earliest eligible time, not a guaranteed alarm.
+Foreground refresh can request LocalDevVPN activation and recheck readiness after
+returning. Background refresh does not try to force-open another app: it records
+the failure and uses bounded recovery. Cellular-only refresh is not supported.
 
 ## Required LocalDevVPN setup
 
-This step is **required** for the current CoreDevice transport path.
+Use **Wi-Fi + official unmodified App Store LocalDevVPN**. VPN Super and an
+additional IKEv2/IPSec tunnel are not required by the CoreDevice path.
 
-For the normal on-device refresh runtime, the expected network stack is:
+Choose two unused IPv4 addresses in the **same subnet** as the iPhone's current
+Wi-Fi network. Configure both with **/32** in LocalDevVPN's Network Configuration.
 
-```text
-iPhone Wi-Fi + official App Store LocalDevVPN
-```
-
-Do **not** enable IKEv2/IPSec, WireGuard, a custom DNS tunnel, a relay server, or a custom VPN app for the normal refresh path. Those were useful during early diagnostics only. The product path is Wi-Fi plus the official unmodified LocalDevVPN.
-
-The important setting is inside **LocalDevVPN → Settings → Network Configuration**. It is **not** the iOS Wi-Fi HTTP Proxy setting.
-
-### What the VPN route is doing
-
-LocalDevVPN is used here to create a virtual route to a **Device IP** that sits inside the iPhone's current Wi-Fi subnet. The Tunnel IP and Device IP are route endpoints, not normal LAN devices.
-
-The reason for choosing same-subnet `/32` addresses is route selection: SideStore opens the CoreDevice/Lockdown path toward the **Device IP**, and iOS must have a valid LocalDevVPN route for that peer while the phone remains attached to Wi-Fi.
-
-In practical terms:
+Example only, for a Wi-Fi network using `192.168.50.x/24`:
 
 ```text
-Wi-Fi subnet        -> the real network the iPhone is on
-Tunnel IP /32       -> LocalDevVPN tunnel-side route address
-Device IP /32       -> synthetic peer address SideStore targets
-SideStore traffic   -> routed through LocalDevVPN to that Device IP
+Tunnel IP: 192.168.50.240/32
+Device IP: 192.168.50.241/32
 ```
 
-If the iPhone moves to a different Wi-Fi subnet, reconfigure these addresses. A route that matched the old Wi-Fi network may be wrong on the new one.
+Do not use the iPhone's actual address, the gateway, an occupied address, or an
+address outside that subnet. Do not copy the example onto a different network.
 
-Configure LocalDevVPN so its **Tunnel IP** and **Device IP** are two unused IPv4 addresses inside the **same subnet as the iPhone's current Wi-Fi network**, and use `/32` for both addresses.
+1. Open LocalDevVPN > Settings > Network Configuration.
+2. Enter the Tunnel IP and Device IP, each with /32.
+3. Enable Allow Intermediate Addresses.
+4. Use Done > Save & Apply, then connect.
+5. Check Session Details to confirm the custom addresses were retained.
 
-Do not leave LocalDevVPN on its default/private tunnel range. SideStore's current CoreDevice path expects the LocalDevVPN peer route to match the Wi-Fi subnet that the iPhone is actually using.
+The **Device IP is the peer** targeted by SideStore; the Tunnel IP is the
+tunnel-side address. These are virtual route endpoints, not additional LAN devices.
+Reconfigure when changing Wi-Fi subnets. This is not the Wi-Fi HTTP Proxy setting.
 
-For example, if the iPhone is connected to Wi-Fi as:
+The transport discovers candidates from the active tunnel and routing table;
+it does not hardcode one private IPv4 range. See [compatibility](docs/COMPATIBILITY.md).
 
-```text
-10.0.0.15/24
-```
+## Guests and Return behavior
 
-choose two unused addresses from that same subnet:
+| Execution mode | Return behavior |
+| --- | --- |
+| Windowed LiveProcess multitasking | Floating button hidden; use existing window controls |
+| Fullscreen/maximized LiveProcess | Return minimizes or activates the host without intentionally terminating the guest |
+| Retained guest reopened | Existing instance reused when still alive; stale instances cleaned before cold launch |
+| Direct host-process guest | Existing restart-return path; guest memory is not preserved |
 
-```text
-Tunnel IP:  10.0.0.240/32
-Device IP:  10.0.0.241/32
-```
+Long-press the Return button to collapse it to an edge tab; tap the tab to restore.
+This does not disable **Guest Controls > Show Return Button**. Position is saved
+and clamped after resizing. iOS may still suspend or terminate retained guests.
 
-If the Wi-Fi network is `192.168.1.x/24`, choose two unused `192.168.1.x/32` addresses instead.
+A LiveContainer guest is not a standalone SideStore InstalledApp. Host refresh
+and guest signing are separate concerns; the feature does not re-sign every guest
+on every refresh or guarantee that any guest process stays alive.
 
-Do **not** use:
+## Verification status
 
-- the iPhone's real Wi-Fi address
-- the router/gateway address
-- an address already used by another device
-- a random address outside the current Wi-Fi subnet
-- the example addresses blindly
+| Scope | Evidence |
+| --- | --- |
+| Standalone CoreDevice transport, staging/install, manual refresh | Verified on iPhone 12 / iOS 26.6.1 |
+| Standalone scheduled refresh with PC disconnected | Recorded proof in the verification report |
+| Combined v2.0.0 compilation and packaging | Both Release builds, 76 CI tests with 2 skipped, local artifact checks |
+| Combined embedded UI and earlier Return interaction | Observed on the test iPhone |
+| Combined verification-result bridge | Matching results received; a newly installed provisioning profile observed |
+| Final automatic windowed/fullscreen visibility | Source/build tested; device confirmation pending |
+| Combined complete host replacement, same-PID resume, unattended refresh across devices | Not established by package verification; further device testing required |
 
-In the official **LocalDevVPN** app:
+Stable release status does not turn a best-effort iOS trigger into a guarantee.
+Task launch, request acceptance, and host handoff are not verified refresh success.
+See [verification details](docs/VERIFICATION.md) and [v2.0.0 notes](docs/RELEASE_NOTES_v2.0.0.md).
 
-1. Open **Settings → Network Configuration**.
-2. Set **Tunnel IP** to the first unused address in the current Wi-Fi subnet with `/32`.
-3. Set **Device IP** to a second unused address in the same Wi-Fi subnet with `/32`.
-4. Enable **Allow Intermediate Addresses**.
-5. Tap **Done**.
-6. Tap **Save & Apply**.
-7. Connect LocalDevVPN.
-8. Open **Session Details** and verify that the tunnel is using the exact values you entered.
-
-> If LocalDevVPN shows its original/default addresses again after the warning/confirmation screen, re-enter your custom Tunnel IP and Device IP, then use **Done → Save & Apply → Connect**.
-
-### Important for local development and diagnostics
-
-During development, some early diagnostic builds used an extra IKEv2/IPSec profile to force a routable IPv4 path and to compare route selection. That was a diagnostic workaround, not the final requirement.
-
-The final path should be treated as:
-
-```text
-1. iPhone connected to Wi-Fi.
-2. Official LocalDevVPN configured with same-subnet /32 Tunnel IP and Device IP.
-3. LocalDevVPN connected and verified in Session Details.
-4. SideStore opened after the tunnel is connected.
-```
-
-The computer and USB are only for building, initial installation, diagnostics, and log capture. They are not part of the intended refresh runtime.
-
-If SideStore cannot reach the CoreDevice path, do not start by changing code. First verify:
-
-- the iPhone is still on the Wi-Fi network used to choose the LocalDevVPN addresses
-- Tunnel IP and Device IP are both in that same Wi-Fi subnet
-- both values end with `/32`
-- **Allow Intermediate Addresses** is enabled
-- LocalDevVPN is connected
-- Session Details still shows the custom values and did not reset to defaults
-
-### Important: which address SideStore uses
-
-For CoreDevice/Lockdown traffic, the **Device IP is the peer address**. SideStore must reach the device peer through that address; the Tunnel IP is the local tunnel-side address.
-
-In other words:
-
-```text
-Tunnel IP  -> LocalDevVPN tunnel side
-Device IP  -> iPhone/CoreDevice peer used by SideStore
-```
-
-The current implementation discovers and validates this same-subnet `/32` peer route before opening the CoreDevice transport. The discovery code is not hardcoded to `10.x` or `192.168.x`; it derives candidates from the active tunnel interface and routing table.
+No deployment targets were raised. Older-device compatibility and optional
+framework behavior still need device coverage. The combined IPA has **five App ID
+registration targets before exact-ID reuse**, separate from the installed-app
+limit. Uninstalling an app does not immediately restore Apple registration quota.
 
 ## Screenshots
+
+The following images show the **standalone SideStore interface**. They do not
+represent the new combined LiveContainer UI.
 
 <p align="center">
   <img src="docs/screenshots/settings-refreshing-apps.png" width="240" alt="SideStore Refreshing Apps settings">
@@ -215,7 +186,7 @@ The current implementation discovers and validates this same-subnet `/32` peer r
 <p align="center">
   <img src="docs/screenshots/refresh-skipped.jpeg" width="240" alt="Refresh Skip">
   <br>
-  <strong>Siri refresh phrase</strong>
+  <strong>Skipped refresh</strong>
 </p>
 
 <p align="center">
@@ -224,247 +195,71 @@ The current implementation discovers and validates this same-subnet `/32` peer r
   <strong>Siri refresh phrase</strong>
 </p>
 
-These screens show the background-refresh controls, configurable scheduling, earliest eligible refresh time, notification status, persisted manual refresh results, preferred refresh time selection, and the Siri shortcut phrase used to trigger refresh.
-
-## Why this exists
-
-Apps signed with a Free Apple Account normally need to be refreshed within Apple's seven-day signing window. This project modifies SideStore so the refresh/install path can run over the iPhone's own LocalDevVPN/CoreDevice connection instead of depending on a computer during normal refresh operation.
-
-### What you get
-
-- **On-device SideStore refresh path** through official LocalDevVPN + CoreDevice.
-- **Free Apple Account / Personal Team** support.
-- **SideStore + up to two personally signed apps** within the normal free-account app limit.
-- **Native iOS background scheduling** using `BGProcessingTask`.
-- Configurable **six-hour, daily, or weekly** refresh scheduling.
-- Persistent refresh history and diagnostic markers.
-- No jailbreak and no custom VPN application.
-- Reproducible GitHub Actions build from pinned upstream revisions.
-
-## Verification status
-
-| Capability | Status |
-| --- | --- |
-| LocalDevVPN → Lockdown/CoreDevice connection | ✅ Verified on real iPhone |
-| CoreDeviceProxy TLS + CDTunnel + RSD | ✅ Verified |
-| AFC IPA staging | ✅ Verified |
-| InstallationProxy install | ✅ Verified |
-| Post-install application verification | ✅ Verified |
-| Manual `Refresh All` over CoreDevice | ✅ Verified |
-| Native background-task registration | ✅ Verified |
-| Native background-task scheduling | ✅ Verified |
-| Schedule/history code and IPA build | ✅ CI verified |
-| Full unattended scheduled refresh with PC disconnected | ✅ Final proof verified |
-
-Tested transport hardware: **iPhone 12 running iOS 26.6.1**.
-
-The latest verified manual `Refresh All` refreshed Spotify and SideStore successfully over the CoreDevice transport in **18.571 seconds**.
-
-See [`docs/VERIFICATION.md`](docs/VERIFICATION.md) for the exact evidence, build hashes, device markers, and reproduction notes.
-
-## Compatibility
-
-The current proof device is **iPhone 12 / iOS 26.6.1**. The next goal is broad compatibility coverage across additional devices, iOS versions, and private Wi-Fi network ranges.
-
-See the live [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md) matrix and report successful or failed tests in [Issue #1](https://github.com/NRG-Wardog/sidestore-auto-refresh/issues/1) or through the **Device verification** issue template.
-
-The implementation is designed to be IPv4-range agnostic. `10.x`, `192.168.x`, and other valid network ranges are not hardcoded; the LocalDevVPN configuration must still use unused `/32` addresses inside the device's current Wi-Fi subnet.
-
-## Requirements
-
-- Free Apple Account / Personal Team
-- Valid Lockdown pairing file
-- Developer Mode
-- Wi-Fi
-- Official unmodified LocalDevVPN from the App Store
-- Same-subnet `/32` LocalDevVPN configuration
-
-Tested topology:
+## Architecture
 
 ```text
-Tunnel IP:       TUNNEL_IP/32
-Device peer IP:  DEVICE_PEER_IP/32
+LiveContainer triggers / embedded SideStore
+    -> refresh coordination and eligibility
+    -> Wi-Fi / LocalDevVPN preflight
+    -> upstream signing and refresh pipeline
+    -> Lockdown -> CoreDeviceProxy TLS -> CDTunnel
+    -> userspace IPv6 adapter -> RSD
+    -> AFC staging / InstallationProxy and profile operations
+    -> correlated verification results and history
 ```
 
-The PC and USB are needed for **building, initial installation, diagnostics, and log capture only**. They are not part of the intended refresh runtime.
+The CoreDevice path preserves service TLS, contiguous CDTunnel writes, heartbeat
+during transport operations, packet-size/flow-control fixes, and corrected FFI
+ownership. It does not use QUIC or RemotePairing dynamic TCP as its product path.
 
-## How it works
-
-```text
-official LocalDevVPN
-        |
-        v
-Lockdown pairing
-        |
-        v
-CoreDeviceProxy over TLS
-        |
-        v
-CDTunnel
-        |
-        v
-jktcp userspace IPv6 adapter
-        |
-        v
-RSD
-        |
-        +--> AFC --> IPA staging
-        |
-        +--> InstallationProxy --> install/refresh
-        |
-        v
-SideStore refresh pipeline
-```
-
-The implementation intentionally does **not** use QUIC or RemotePairing dynamic TCP in the current product path.
-
-## What is patched
-
-This repository does not vendor a permanent copy of SideStore or its dependency source trees. GitHub Actions checks out pinned upstream revisions and applies focused patches at build time.
-
-### SideStore integration
-
-- Composite pairing records prefer the Lockdown/CoreDevice path.
-- LocalDevVPN route discovery derives and validates the device peer address.
-- The obsolete IKEv2 requirement is not applied to the CoreDevice path.
-- CoreDevice connections are created from the Lockdown pairing file and device endpoint.
-- CoreDevice services use RSD for device-service discovery.
-- AFC staging and InstallationProxy installation are available through RSD.
-- The gateway reuses an active CoreDevice transport and detects stale heartbeat state before creating a new one.
-- Pairing-file/provider cleanup is serialized to avoid ownership errors and double frees.
-- Refresh/install operations emit public diagnostic markers without logging private keys or sensitive pairing material.
-
-### CoreDevice / idevice transport
-
-- CoreDeviceProxy keeps `com.apple.mobile.heartbeat` Marco/Polo alive for the full transport operation.
-- Service TLS remains enabled when Lockdown returns `EnableServiceSSL=true`.
-- CDTunnel requests are encoded as one contiguous frame before writing.
-- Effective TCP MSS is limited to 1340 bytes because CoreDeviceProxy can drop larger host-to-device IPv6 packets despite advertising a larger MTU.
-- AFC FFI operations use the local async runtime path to avoid a conflicting executor.
-- AFC/provider and plist-array ownership is corrected at the FFI boundary.
-
-### jktcp reliability
-
-- Zero-window persist probes recover transfers when a window-update packet is lost.
-- Window close/reopen events expose transport diagnostics.
-- Timer-driven retransmission errors wake blocked readers.
-- Transport write errors propagate instead of leaving a transfer waiting indefinitely.
-
-## Native background refresh
-
-SideStore registers a native iOS `BGProcessingTask` with:
-
-```text
-com.SideStore.SideStore.automatic-refresh
-```
-
-When iOS starts an enabled scheduled task, SideStore:
-
-1. Reschedules the next task.
-2. Waits for the CoreDevice transport boot sequence.
-3. Starts the database if necessary.
-4. Selects installed apps eligible for refresh.
-5. Includes SideStore in the refresh operation.
-6. Runs the existing signing, provisioning, staging, and installation pipeline.
-7. Cancels the active operation if iOS expires the task.
-8. Reports success only when all nested refresh results succeed.
-
-Important markers:
-
-```text
-[AUTO_REFRESH] REGISTER_PASS
-[AUTO_REFRESH] SCHEDULE_PASS
-[AUTO_REFRESH] TRIGGER source=bgprocessing
-[AUTO_REFRESH] ELIGIBLE_APPS
-[AUTO_REFRESH] AUTH_PREFLIGHT_PASS
-[AUTO_REFRESH] OPERATION_START
-[AUTO_REFRESH] COMPLETE success=true
-```
-
-`REGISTER_PASS` and `SCHEDULE_PASS` prove registration/submission only. They do **not** prove that iOS executed the task.
-
-Full PC-free background automation is considered proven after a scheduled task runs with the PC disconnected and produces the trigger, operation, and successful completion evidence documented in [`docs/VERIFICATION.md`](docs/VERIFICATION.md).
-
-## Refresh history and alerts
-
-The patched build includes persisted refresh history for scheduled and manual operations. It records accepted schedules, starts, completion, failure, skipped runs, background expiration, and manual refresh results.
-
-A local notification with sound is requested when iOS actually starts an enabled scheduled task. It is not pre-scheduled for the preferred refresh time; iOS remains in control of actual background execution.
-
-History starts with installation of this feature and does not reconstruct old runs from previous logs.
+The combined orchestration includes host-last/handoff handling. Host replacement
+can terminate the process; a handoff is not a verified new signing lifetime.
 
 ## Build it yourself
 
-The public GitHub Actions workflow reproduces the prebuilt IPA from pinned upstream revisions.
+This repository contains **build-time patches**, not a vendored permanent copy of
+LiveContainer or SideStore. Workflows fetch pinned upstream revisions.
 
-1. Fork this repository to your GitHub account.
-2. Open **Actions** in your fork.
-3. Enable Actions if GitHub asks.
-4. Select **Build Current SideStore**.
-5. Click **Run workflow** on `main`.
-6. Open the successful run.
-7. Download the `SideStore-v30-background-automation` artifact.
-8. Extract the ZIP and use `SideStore.ipa`.
+1. Fork the repository and enable Actions.
+2. Choose **LiveContainer embedded SideStore build** for the combined IPA, or
+   **Build Current SideStore** for standalone.
+3. Run the workflow on `main`.
+4. Download the successful run's artifact:
+   `LiveContainer-SideStore-AutoRefresh-IPA` or
+   `SideStore-v30-background-automation`.
+5. Extract and sign the IPA with your own account.
 
-Workflow source: [`.github/workflows/build-current.yml`](.github/workflows/build-current.yml)
+[Combined workflow](.github/workflows/livecontainer-build.yml)
+| [Standalone workflow](.github/workflows/build-current.yml)
 
-The workflow currently pins these revisions:
+For the exact published v2.0.0 binary, use builder commit `f20e14e`; the original
+release tag was retained when its preview asset was updated. Exact dependency
+revisions and artifact provenance are recorded in the release notes and workflows.
 
-- SideStore: `394bb4eb331cb4afc23517af2fc847ec103af57f`
-- minimuxer: `e0de126ec6773c02afe7d965def86ddffd79cbeb`
-- idevice: `ebd7dadfc55d1c4facee3d11ecf5b28e20548b57`
-- jktcp: `e674e1eee6d5943e13b1eba0bd24a9dd0b2fa020`
+Key patches cover combined transport, embedded startup/Keychain, refresh
+coordination, XPC result transfer, guest Return, and upstream combined packaging.
+Rust and Swift builds, source checks, and IPA verification run on macOS/Xcode.
 
-Patch scripts:
-
-- `scripts/patch_coredevice_idevice.py`
-- `scripts/patch_sidestore_integration.py`
-- `scripts/patch_background_automation.py`
-- `scripts/patch_local_idevice_package.py`
-- `scripts/patch_jktcp_reliability.py`
-
-The Action compiles the Rust and Swift components on macOS/Xcode, validates the patched source, runs repository and transport tests, verifies the IPA contents, and uploads the resulting IPA as a workflow artifact.
-
-## Local repository checks
+## Local checks
 
 ```bash
 python -m unittest discover -s tests -v
+git diff --check
 ```
 
-Public-release safeguards are documented in:
+Compiler-dependent tests require their toolchains. Source/static checks do not
+replace iPhone validation.
 
-- [`LICENSE`](LICENSE)
-- [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md)
-- [`CONTRIBUTING.md`](CONTRIBUTING.md)
-- [`SECURITY.md`](SECURITY.md)
-- [`docs/VERIFICATION.md`](docs/VERIFICATION.md)
-- [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md)
-- [`tests/test_repository.py`](tests/test_repository.py)
+## Security, licensing, and contributions
 
-## Security
+Never publish credentials, pairing files, private keys, personal signed IPAs,
+unnecessary device identifiers, or complete private device logs.
 
-Never upload or commit:
+Original repository-authored work is MIT-licensed unless stated otherwise.
+Upstream code and derived binaries retain their applicable licenses.
 
-- pairing files
-- certificate private keys
-- signed IPAs containing personal signing material
-- unnecessary device identifiers
-- private device logs
+[Contributing](CONTRIBUTING.md) | [Security](SECURITY.md) |
+[License](LICENSE) | [Third-party notices](THIRD_PARTY_NOTICES.md)
 
-The public repository intentionally contains build-time patch scripts and documentation rather than personal signing material.
-
-## Licensing
-
-Original repository-authored builder scripts, tests, and documentation are MIT-licensed unless a file states otherwise. SideStore and other upstream projects retain their own applicable license terms, and those upstream licenses continue to apply to upstream-derived code and the distributed modified IPA. See [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
-
-## Contributing
-
-Bug reports, device compatibility results, transport diagnostics, documentation improvements, and focused fixes are welcome. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) before opening a pull request.
-
-If you test the project on another iPhone/iPad, iOS version, or Wi-Fi network family, report the result (successful or failed). That data expands the public compatibility matrix.
-
-## Support the project
-
-If this solves the SideStore seven-day refresh problem for you, **star the repository** so other SideStore users can find it.
-
-If you test it on another iPhone/iOS version, open an issue with the result (successful or failed). Real-device compatibility data is more valuable than guesses.
+Report device, iOS, variant/build, network family, and non-sensitive results through
+[Issue #1](https://github.com/NRG-Wardog/sidestore-auto-refresh/issues/1).

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -4,11 +4,26 @@ This page tracks real-device results for the SideStore Auto-Refresh CoreDevice p
 
 The implementation does not hardcode `10.x`, `192.168.x`, or another specific IPv4 range. It derives the LocalDevVPN peer from the active interface and routing table. The LocalDevVPN Tunnel IP and Device IP still need to be configured as unused `/32` addresses inside the iPhone's current Wi-Fi subnet.
 
-## Verified proof device
+## Standalone SideStore proof device
 
 | Device | iOS | LocalDevVPN | Manual Refresh All | Scheduled PC-free refresh |
 | --- | --- | --- | --- | --- |
 | iPhone 12 | 26.6.1 | Official App Store LocalDevVPN, same-subnet `/32` route | ✅ Verified | ✅ Final proof verified |
+
+## Combined LiveContainer v2.0.0
+
+The combined variant uses the same intended Wi-Fi + official LocalDevVPN
+CoreDevice route, but the standalone scheduled-refresh result above is not proof
+of the combined host replacement or unattended execution path.
+
+On iPhone 12 / iOS 26.6.1, embedded UI and earlier Return-control interaction were
+observed, as were matching refresh results and a newly installed provisioning
+profile. Final windowed/fullscreen control visibility, same-PID resume, complete
+host replacement, and unattended combined refresh still need device validation.
+
+Published build `f20e14e` passed Release compilation and package checks. No minimum
+deployment targets were raised. Other OS/device combinations remain unverified.
+Cellular-only refresh is not supported by this release.
 
 ## Community compatibility reports
 
@@ -26,6 +41,7 @@ Use [Issue #1](https://github.com/NRG-Wardog/sidestore-auto-refresh/issues/1) or
 A useful report includes:
 
 - device model
+- standalone or combined variant, and installed build/version
 - iOS version
 - Wi-Fi network family (exact addresses are not required)
 - whether official LocalDevVPN remained connected

--- a/docs/RELEASE_NOTES_v2.0.0.md
+++ b/docs/RELEASE_NOTES_v2.0.0.md
@@ -1,68 +1,116 @@
 # LiveContainer + SideStore Auto-Refresh v2.0.0
 
-**Preview release.** This introduces the combined LiveContainer + embedded
-SideStore variant. Compilation and package verification passed; successful
-signing, installation, host replacement and unattended refresh of this combined
-variant still require on-device validation. This release contains only the
-LiveContainer combined build.
+Stable release of LiveContainer with patched embedded SideStore, native refresh
+automation, LocalDevVPN/CoreDevice transport, and guest Return controls.
+Updated September 8, 2026 with build `f20e14e`.
 
-## Downloads
+This release contains only the combined LiveContainer build, not standalone
+SideStore v1.0.2. Release numbering does not replace upstream app version numbers.
 
-- `LiveContainer-SideStore-AutoRefresh-v2.0.0.ipa`: new combined preview.
-- `SHA256SUMS.txt`: integrity checksum for the combined IPA.
+## Download and installation
 
-Version v2.0.0 identifies this repository release, not the upstream applications'
-internal version numbers. The combined IPA must be signed with your own account.
+- `LiveContainer-SideStore-AutoRefresh-v2.0.0.ipa`
+- `SHA256SUMS.txt`
+- `RELEASE_NOTES_v2.0.0.md`
 
-## Included in the combined preview
+Sign with your own Apple account using a compatible installer. Update over the
+existing same-team, same-identifier installation; do not delete LiveContainer
+first. Back up important guest data. Standalone SideStore-to-combined data
+migration is not provided.
 
-- LiveContainer with patched embedded SideStore, its dependencies and widget.
-- Preserved LiveProcess, ShareExtension and LaunchAppExtension bundles.
-- Upstream combined packaging, including executable conversion, entitlement
-  preparation, app-group metadata, URL schemes and intent metadata.
-- Six-hour, daily and weekly scheduling controls with local clock selection.
-- Native background processing, a lightweight background-refresh watchdog and
-  launch/resume recovery paths; Personal Automation is not required setup.
-- Target-deadline scheduling with an initial one-hour lead time. iOS still
-  controls execution and may delay or omit a background task.
-- Shared run coalescing, compact due-state checks, persisted retry timing and
-  refresh history.
-- Host-handoff and post-relaunch verification logic, plus guest-signature checks.
-  These are implemented paths, not proof of successful host or guest refresh.
-- Optional AlarmKit deadline protection on iOS 26.1+ when authorized. The alarm
-  is a warning with a user-operated Refresh Now action, not an automatic executor.
-- Embedded SideStore console-log retention limits to avoid unlimited log growth.
+## Combined application and transport
+
+- Upstream combined packaging: converted SideStoreApp.framework, nested
+  dependencies, relocated widget, app groups, URL schemes, and intent metadata.
+- Preserves LiveProcess, ShareExtension, LaunchAppExtension, and the combined widget.
+- Ports the LocalDevVPN/CoreDevice path into embedded SideStore: pairing selection,
+  service TLS, contiguous CDTunnel handshake, RSD, AFC/install routing, and
+  transport dependency fixes.
+- Explicit transport-selection/readiness diagnostics. The CoreDevice path does
+  not require VPN Super or an additional IKEv2/IPSec VPN.
+- Existing upstream transport modes remain available where supported.
+
+## Embedded SideStore startup and authentication
+
+- Corrects startup hooks and host bundle/profile identity handling.
+- Prevents database retries from attaching the same persistent store twice and
+  masking the original startup error.
+- Accepts upstream reusable authentication paths instead of requiring saved email.
+- Shared-Keychain credential handling and migration, with non-secret
+  presence/status diagnostics for UI and refresh-process access.
+- Navigation back from embedded SideStore to LiveContainer.
+
+## Refresh automation and status
+
+- Six-hour, daily, and weekly schedules with local clock selection.
+- Native background processing, lightweight watchdog, and launch/resume recovery;
+  Shortcuts Personal Automation is not required setup.
+- Deadline-oriented scheduling, initially with a one-hour lead time, compact due
+  checks, run coalescing, persisted retry backoff, and expiration monitoring.
+- Optional AlarmKit safety alerts on iOS 26.1+ when available and authorized, with
+  local-notification fallback. Alarm actions require user interaction.
+- Host-handoff/post-relaunch verification and guest-signature health paths.
+- Wi-Fi preflight before expensive transport work; foreground LocalDevVPN enable
+  handoff with readiness rechecking rather than assuming activation succeeded.
+- Background VPN failures use explicit status and bounded retry, not app launching.
+- Reactive readiness/status UI and preserved backoff across initial scheduling.
+- Manual/scheduled history, lifecycle notifications, stable selection/deletion,
+  and bounded embedded console-log retention.
+- Correlated run IDs and verification results across the existing XPC bridge.
+  Missing, mismatched, and empty results now have distinct explanations.
+
+## Guest Return controls and multitasking
+
+- Movable control with safe-area/keyboard-aware placement and saved position.
+- Long-press collapse to an edge tab; tap to restore. Collapse does not change the
+  global Guest Controls preference.
+- Floating control automatically hides in windowed multitasking and is available
+  in fullscreen/maximized guests, subject to the global preference.
+- Corrected virtual-window input layering and control cleanup.
+- LiveProcess Return uses upstream minimize/host-activation without intentionally
+  terminating the guest; reopening prefers its retained instance.
+- Per-window launch ownership, container identity checks, and stale-instance
+  cleanup prevent cross-guest callbacks and duplicate launches.
+- Direct host-process guests use restart-return, not preserved resume.
+  iOS can still suspend or terminate retained LiveProcess guests.
 
 ## Requirements and limitations
 
-- Free Apple Account / Personal Team, valid pairing file, Developer Mode,
-  Wi-Fi and official unmodified App Store LocalDevVPN for the intended transport.
-- The combined package has five App ID registration targets before exact-ID
-  reuse. Sufficient Apple registration quota is required for initial signing;
-  this is separate from the three-installed-app limit.
-- Removing apps or App IDs does not guarantee immediately available quota.
-- No deployment targets were raised by this release. Launch compatibility across
-  older supported iOS versions still needs real-device testing.
-- Background execution, deadline protection, expiration recovery and host
-  self-replacement are not guaranteed by this preview.
-- Do not infer successful refresh from a task launch or an accepted installation
-  request. Check actual installation and signing validity after refresh.
+- Free Apple Account / Personal Team, pairing file, Developer Mode, Wi-Fi, and
+  official unmodified App Store LocalDevVPN with a compatible local route.
+- The intended refresh runtime does not require a PC, USB, external relay, paid
+  developer membership, or custom VPN extension. Initial signing/install requires
+  a compatible setup and sufficient account quota.
+- Five App ID registration targets before exact-ID reuse, separate from the
+  installed-app limit. Uninstalling apps does not immediately release quota.
+- Cellular-only refresh is not supported.
+- Deployment targets are unchanged; optional newer APIs are availability-guarded.
+  Older-device compatibility still needs testing on those devices.
+- iOS may delay or omit background tasks. A deadline, submitted request, task
+  launch, or installation handoff is not proof of completed refresh.
+- Host self-replacement and unattended combined refresh are not universally proven.
+  Check actual signing validity, not just a successful UI or handoff message.
 
-Back up important app data before testing. Use your installer to sign the combined
-IPA. A standalone-to-combined data migration is not provided here.
-Keep credentials, pairing files and private signing material out of bug reports.
+## Verification and provenance
 
-## Provenance
+- Builder: `f20e14e43b4048c5b5791e7d4b0bb6e32930c10a`
+- [Successful build 34238644076](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/runs/34238644076)
+- LiveContainer: `12377cf3b91d51739a33f14a302e5f522b238593`
+- Embedded SideStore: `10ffa01ecdfe4203a7ad5d7f41c0d5de03bd8abb`
+- CI: 76 tests, 2 skipped; both Release builds passed.
+- Combined semantic/runtime package and embedded transport checks passed.
+  The downloaded IPA was independently rechecked locally.
+- Size: 37,389,675 bytes.
+- SHA-256: `1c29648ee99abd67cd6244d0405f2ab9df0beca92adb4c35bed5c133eb7d974e`
 
-Combined preview:
+Earlier device testing confirmed embedded UI operation, Return-control interaction,
+and transfer of refresh verification results, with a newly installed provisioning
+profile observed. The final windowed/fullscreen visibility change passed
+source/build checks but has not yet been confirmed on-device. Package checks
+do not establish same-PID resume or complete host replacement.
 
-- Builder commit: `85f024438c6412d9a14f11d9fe4a79134bfe39c3`
-- [Successful build run 34091379185](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/runs/34091379185)
-- LiveContainer revision: `12377cf3b91d51739a33f14a302e5f522b238593`
-- Embedded SideStore revision: `10ffa01ecdfe4203a7ad5d7f41c0d5de03bd8abb`
-- Size: 37,206,711 bytes
-- SHA-256: `9fbbfbacbf8b31927cfde70fe1d799b6af4f1a9c6076819fc2849a00e861f58d`
+This replaces the earlier preview asset without rebuilding the IPA. The existing
+release tag is retained; the explicit builder commit above identifies the source
+for the updated binary.
 
-The IPA is an existing build output; publishing this release did not rebuild
-or alter it. Local checks: 13 tests passed, two Swift-dependent tests
-skipped, and combined-package semantic verification passed.
+Keep credentials, pairing records, and private signing material out of reports.

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -2,14 +2,37 @@
 
 ## Scope
 
-The current build targets an iPhone 12 running iOS 26.6.1 with a Free Apple
+This report distinguishes standalone SideStore evidence from the combined
+LiveContainer + embedded SideStore release. Proof from one variant must not be
+assumed to cover the other.
+
+The test setup uses an iPhone 12 running iOS 26.6.1 with a Free Apple
 Account, Developer Mode, official App Store LocalDevVPN, Wi-Fi, and a valid
 Lockdown pairing file.
 
 The PC is used only for building, initial installation, diagnostics, and log
 capture. It is not part of the intended refresh runtime.
 
-## Proven
+## Combined v2.0.0 release
+
+- Published builder: `f20e14e43b4048c5b5791e7d4b0bb6e32930c10a`.
+- [Build 34238644076](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/runs/34238644076):
+  76 tests, 2 skipped; both Release builds and package/transport checks passed.
+- Downloaded IPA independently passed combined semantic/runtime package checks.
+- Size: 37,389,675 bytes.
+- SHA-256: `1c29648ee99abd67cd6244d0405f2ab9df0beca92adb4c35bed5c133eb7d974e`.
+- Earlier device tests observed embedded UI startup, Return-control interaction,
+  and transfer of matching refresh verification results. A newly installed host
+  provisioning profile was independently observed.
+- These observations do not alone prove executable replacement, same-PID guest
+  preservation, or unattended combined refresh.
+- The final automatic windowed/fullscreen control visibility change has passed
+  source/build checks but awaits device confirmation.
+
+See [release notes](RELEASE_NOTES_v2.0.0.md) for the complete changes and limitations.
+The original release tag was retained; use the explicit builder SHA for this IPA.
+
+## Standalone SideStore: proven
 
 - Lockdown reaches CoreDeviceProxy on the LocalDevVPN same-subnet route.
 - CoreDeviceProxy service TLS is enabled.
@@ -24,7 +47,7 @@ capture. It is not part of the intended refresh runtime.
 - Full unattended scheduled refresh with the PC disconnected is verified on the
   current proof device.
 
-## Final PC-free proof
+## Standalone final PC-free proof
 
 The final proof condition is a scheduled iOS background task running while the
 PC and USB are disconnected, then reaching the refresh operation and completing
@@ -53,7 +76,7 @@ Do not upload pairing files, certificates, private keys, full private device
 logs, unnecessary device identifiers, or signed IPAs containing personal signing
 material.
 
-## Current release IPA
+## Standalone v1.0.2 IPA
 
 The public **v1.0.2** IPA is **27,566,058 bytes** with SHA-256:
 

--- a/scripts/package_livecontainer_combined.py
+++ b/scripts/package_livecontainer_combined.py
@@ -76,6 +76,11 @@ def verify(path, side_product=None):
         assert b'LCReturnControlPosition' in host_code, 'Movable return control missing'
         bootstrap_code = archive.read(base + '/Frameworks/LiveContainerShared.framework/LiveContainerShared')
         support_code = archive.read(base + '/Frameworks/SideStoreSupport.framework/SideStoreSupport')
+        for code in (host_code, bootstrap_code):
+            assert b'CONTROL_COLLAPSED' in code and b'CONTROL_RESTORED' in code, 'Restorable Return control missing'
+        assert b'finishRefresh:runID:verification:' in support_code, 'XPC result receiver missing'
+        assert b'refreshAllAppsWithIdentifier:mangledTypeName:refreshRunID:' in support_code, 'XPC run identity missing'
+        assert b'RESULT_RECEIVED' in support_code, 'Host result persistence missing'
         assert b'installSideStoreHooks' in bootstrap_code, 'Embedded SideStore hook invocation missing'
         assert b'EMBEDDED_SIDESTORE_STARTUP_FIX_V1' in support_code, 'Embedded SideStore startup fix missing'
         for name in ('Intents.intentdefinition', 'ViewApp.intentdefinition', 'Metadata.appintents/extract.actionsdata'):

--- a/scripts/package_livecontainer_combined.py
+++ b/scripts/package_livecontainer_combined.py
@@ -72,6 +72,8 @@ def verify(path, side_product=None):
         assert b'liveContainerAutoRefreshVerification' in executable, 'Patched embedded operation missing'
         host_code = archive.read(base + '/Frameworks/LiveContainerSwiftUI.framework/LiveContainerSwiftUI')
         assert b'liveContainerAutoRefresh' in host_code, 'Host automation missing'
+        assert b'lcReturnToHost' in host_code, 'Guest return action missing from host binary'
+        assert b'LCReturnControlPosition' in host_code, 'Movable return control missing'
         bootstrap_code = archive.read(base + '/Frameworks/LiveContainerShared.framework/LiveContainerShared')
         support_code = archive.read(base + '/Frameworks/SideStoreSupport.framework/SideStoreSupport')
         assert b'installSideStoreHooks' in bootstrap_code, 'Embedded SideStore hook invocation missing'

--- a/scripts/package_livecontainer_combined.py
+++ b/scripts/package_livecontainer_combined.py
@@ -74,6 +74,7 @@ def verify(path, side_product=None):
         assert b'liveContainerAutoRefresh' in host_code, 'Host automation missing'
         assert b'lcReturnToHost' in host_code, 'Guest return action missing from host binary'
         assert b'LCReturnControlPosition' in host_code, 'Movable return control missing'
+        assert b'virtual_window_chrome' in host_code, 'Multitasking Return input-layer fix missing'
         bootstrap_code = archive.read(base + '/Frameworks/LiveContainerShared.framework/LiveContainerShared')
         support_code = archive.read(base + '/Frameworks/SideStoreSupport.framework/SideStoreSupport')
         for code in (host_code, bootstrap_code):

--- a/scripts/patch_background_automation.py
+++ b/scripts/patch_background_automation.py
@@ -1019,13 +1019,20 @@ def patch_background_operation(sidestore: Path) -> None:
             throw error
         }
 
-        guard AuthManager.shared.isAuthenticated else {
+        // Match AuthenticationOperation's cached-session and silentSignIn paths.
+        // This checks available authentication material, not server validity.
+        let auth = AuthManager.shared
+        let hasPasswordCredentials = auth.currentAppleID != nil && auth.hasStoredPassword
+        let hasTokenCredentials = auth.adsid != nil && auth.hasStoredXcodeToken
+        let hasReusableSession = auth.session != nil && auth.team != nil && CertificateManager.shared.activeCertificate != nil
+        debugLog("[AUTO_REFRESH] AUTH_CREDENTIAL_VISIBILITY password_path=\\(hasPasswordCredentials) token_path=\\(hasTokenCredentials) session_path=\\(hasReusableSession)")
+        guard hasPasswordCredentials || hasTokenCredentials || hasReusableSession else {
             let error = NSError(
                 domain: "com.SideStore.Authentication",
                 code: 1004,
-                userInfo: [NSLocalizedDescriptionKey: "Open SideStore and sign in before automatic refresh can run."]
+                userInfo: [NSLocalizedDescriptionKey: "The refresh process cannot access saved sign-in credentials or a reusable session. Open embedded SideStore to check your account."]
             )
-            debugLog("[AUTO_REFRESH] AUTH_PREFLIGHT_FAIL authenticated=false")
+            debugLog("[AUTO_REFRESH] AUTH_PREFLIGHT_FAIL reason=no_accessible_authentication_path")
             self.scheduleFinishedRefreshingNotification(for: .failure(error), delay: 0)
             throw error
         }
@@ -1149,7 +1156,7 @@ def patch_background_operation(sidestore: Path) -> None:
         "activeRefreshGroup",
         "group?.cancel()",
         "guard !self.isCancelled",
-        "AuthManager.shared.isAuthenticated",
+        "guard hasPasswordCredentials || hasTokenCredentials || hasReusableSession else",
         verification_marker,
         "persistAutomaticHostHandoff",
         "persistAutomaticRefreshVerification",

--- a/scripts/patch_combined_refresh_contract.py
+++ b/scripts/patch_combined_refresh_contract.py
@@ -59,6 +59,8 @@ def verify_ipa(path: Path) -> dict:
         assert tuple(map(int, info.get("MinimumOSVersion", "999").split("."))) <= (15, 0, 0)
         embedded = archive.read(base + "/Frameworks/SideStoreApp.framework/SideStore")
         assert b"LiveContainerRefreshManifestV2" in embedded, "Incomplete-result verification contract not embedded"
+        assert b"[LC_KEYCHAIN] SHARED_GROUP_SELECTED" in embedded, "Shared Keychain route missing from embedded executable"
+        assert b"LCSharedKeychainReadyV1" in embedded, "Legacy Keychain migration contract missing"
         for name in archive.namelist():
             if name.endswith("/"):
                 continue
@@ -85,7 +87,7 @@ def verify_ipa(path: Path) -> dict:
                 offset += size
             images.append({"image": name, "alarmkit": alarm or "absent"})
     assert images, "No arm64 images were inspected"
-    result = {"runtime_contract": 2, "configuration": "passed", "alarmkit_linkage": images,
+    result = {"runtime_contract": 2, "shared_keychain_contract": 1, "configuration": "passed", "alarmkit_linkage": images,
               "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
               "device_runtime": "NOT TESTED; requires signed on-device validation"}
     output = path.with_suffix(".runtime-verification.json")
@@ -100,5 +102,9 @@ if __name__ == "__main__":
         print("SHA256=" + result["sha256"])
     elif len(sys.argv) == 2:
         patch(Path(sys.argv[1]))
+        # This CLI is invoked twice by the combined workflow, after the upstream
+        # background-operation patch. Standalone SideStore is not changed.
+        from patch_embedded_keychain import patch as patch_shared_keychain
+        patch_shared_keychain(Path(sys.argv[1]))
     else:
         raise SystemExit("usage: patch_combined_refresh_contract.py <embedded-root> | --verify-ipa <file.ipa>")

--- a/scripts/patch_embedded_keychain.py
+++ b/scripts/patch_embedded_keychain.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Explicit, shared Keychain namespace for combined SideStore UI and LiveProcess.
+
+Run AFTER background and startup patches. No new entitlements, IDs, transport,
+plaintext credential storage, or guard bypass. Existing secrets migrate only
+within the exact SideStore service and already authorized access groups.
+"""
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+MARKER = "LC_EMBEDDED_SHARED_KEYCHAIN_V1"
+TEMPLATE = Path(__file__).parent / "templates/embedded_shared_keychain.swift"
+
+
+def once(text: str, old: str, new: str) -> str:
+    if text.count(old) != 1:
+        raise ValueError(f"embedded keychain: changed upstream anchor {old[:100]!r}")
+    return text.replace(old, new, 1)
+
+
+def patch(root: Path) -> None:
+    path = root / "AltStore/Core/Components/Keychain.swift"
+    operation = root / "SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift"
+    original = path.read_text(encoding="utf-8")
+    text = original
+    helper = TEMPLATE.read_text(encoding="utf-8")
+    if MARKER not in text:
+        text = once(text, "import Foundation\n", "import Foundation\nimport Security\n")
+        text = once(text, "KeychainAccess.Keychain(service: Bundle.Info.appbundleIdentifier)\n                                            .accessibility(.afterFirstUnlock)\n                                            .synchronizable(true)",
+                    "LCEmbeddedSharedKeychain.makeClient()")
+        text = once(text, "case is Data.Type: return try? Keychain.shared.keychain.getData(self.key) as? Value",
+                    "case is Data.Type: return LCEmbeddedSharedKeychain.read(self.key, client: Keychain.shared.keychain) as? Value")
+        text = once(text, "case is String.Type: return try? Keychain.shared.keychain.getString(self.key) as? Value",
+                    "case is String.Type: return LCEmbeddedSharedKeychain.readString(self.key, client: Keychain.shared.keychain) as? Value")
+        text = once(text, "case is Data.Type: Keychain.shared.keychain[data: self.key] = newValue as? Data",
+                    "case is Data.Type: LCEmbeddedSharedKeychain.write(self.key, data: newValue as? Data, client: Keychain.shared.keychain)")
+        text = once(text, "case is String.Type: Keychain.shared.keychain[self.key] = newValue as? String",
+                    "case is String.Type: LCEmbeddedSharedKeychain.write(self.key, data: (newValue as? String).map { Data($0.utf8) }, client: Keychain.shared.keychain)")
+        text = once(text, "        self.migrateLegacyKeychainItems()", "        LCEmbeddedSharedKeychain.prepare(self.keychain)\n        if LCEmbeddedSharedKeychain.isReady(self.keychain) { self.migrateLegacyKeychainItems() }")
+        text = once(text, 'get { try? self.keychain.getData("importedCert_" + serial) }',
+                    'get { LCEmbeddedSharedKeychain.read("importedCert_" + serial, client: self.keychain) }')
+        text = once(text, '''            if let data = newValue {
+                try? self.keychain.set(data, key: "importedCert_" + serial)
+            } else {
+                try? self.keychain.remove("importedCert_" + serial)
+            }''', '            LCEmbeddedSharedKeychain.write("importedCert_" + serial, data: newValue, client: self.keychain)')
+        text = once(text, "        try? self.keychain.removeAll()", "        LCEmbeddedSharedKeychain.clearAll(self.keychain)")
+        text += "\n" + helper + "\nextension Keychain {\n    func embeddedAuthenticationFailure() -> NSError { LCEmbeddedSharedKeychain.authenticationFailure() }\n}\n"
+    elif helper not in text:
+        raise ValueError("outdated shared keychain patch: apply to clean pinned source")
+    op = operation.read_text(encoding="utf-8")
+    if "Keychain.shared.embeddedAuthenticationFailure()" not in op:
+        start = op.index("        guard hasPasswordCredentials || hasTokenCredentials || hasReusableSession else {")
+        end = op.index('            debugLog("[AUTO_REFRESH] AUTH_PREFLIGHT_FAIL', start)
+        # Keep the guard, logging, failure notification, and throwing behavior.
+        replacement = "        guard hasPasswordCredentials || hasTokenCredentials || hasReusableSession else {\n            let error = Keychain.shared.embeddedAuthenticationFailure()\n"
+        op = op[:start] + replacement + op[end:]
+    assert "guard hasPasswordCredentials || hasTokenCredentials || hasReusableSession else" in op
+    assert 'throw error' in op
+    # Both transforms are validated before writing either file.
+    path.write_text(text, encoding="utf-8")
+    operation.write_text(op, encoding="utf-8")
+    if compiler := shutil.which("swiftc"):
+        for file in (path, operation):
+            subprocess.run([compiler, "-frontend", "-parse", str(file)], check=True)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: patch_embedded_keychain.py <embedded-sidestore-root>")
+    patch(Path(sys.argv[1]))

--- a/scripts/patch_embedded_sidestore_startup.py
+++ b/scripts/patch_embedded_sidestore_startup.py
@@ -174,8 +174,42 @@ def patch_database(path: Path) -> None:
 
 def patch(live_root: Path, sidestore_root: Path) -> None:
     patch_hooks(live_root / "SideStoreSupport" / "SideStoreHooks.m")
+    patch_return_button(live_root / "SideStoreSupport" / "SideStoreHooks.m")
+    patch_auth_storage(sidestore_root / "SideStore" / "Core" / "Auth" / "AuthManager.swift")
     patch_bootstrap(live_root / "LiveContainer" / "LCBootstrap.m")
     patch_database(sidestore_root / "AltStore" / "Core" / "Model" / "DatabaseManager" / "DatabaseManager.swift")
+
+
+def patch_return_button(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    if "SS_RETURN_BUTTON_V1" in text:
+        return
+    text = replace_once(text,
+        "    NSMutableArray* oldToolBarItems = [self.navigationItem.leftBarButtonItems mutableCopy];",
+        '    // SS_RETURN_BUTTON_V1: messaging a nil array silently drops the button.\n'
+        '    escapeItem.accessibilityLabel = @"Return to LiveContainer";\n'
+        '    NSMutableArray* oldToolBarItems = [self.navigationItem.leftBarButtonItems mutableCopy] ?: [NSMutableArray array];',
+        "return button array")
+    path.write_text(text, encoding="utf-8")
+
+
+def patch_auth_storage(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    if "AUTH_STORAGE_READBACK_V1" in text:
+        return
+    for key, label in (("appleIDEmailAddress", "AppleID email"),
+                       ("appleIDPassword", "AppleID password"),
+                       ("appleIDAdsid", "AppleID account ID"),
+                       ("appleIDXcodeToken", "AppleID token")):
+        text = replace_once(text, f"        set {{ Keychain.shared.{key} = newValue }}",
+            f'''        set {{
+            Keychain.shared.{key} = newValue
+            // AUTH_STORAGE_READBACK_V1: report persistence, never the credential.
+            let matches = Keychain.shared.{key} == newValue
+            let status = matches ? (newValue == nil ? "REMOVED" : "SAVED") : "SAVE_FAILED"
+            debugLog("[\\(status)] {label} readback_matches=\\(matches) process_id=\\(ProcessInfo.processInfo.processIdentifier)")
+        }}''', f"{label} storage diagnostics")
+    path.write_text(text, encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/scripts/patch_guest_return.py
+++ b/scripts/patch_guest_return.py
@@ -22,6 +22,8 @@ CONTROL = GEOMETRY + r'''
 @property(nonatomic, copy) void (^action)(void);
 @property(nonatomic) CGPoint position;
 @property(nonatomic) CGRect keyboardFrame;
+@property(nonatomic) BOOL collapsed;
+@property(nonatomic, copy) NSString *expandedHint;
 @end
 @implementation LCReturnControl
 - (instancetype)initWithFrame:(CGRect)frame {
@@ -40,12 +42,14 @@ CONTROL = GEOMETRY + r'''
     [self.button setImage:[UIImage systemImageNamed:@"arrow.uturn.backward.circle.fill"] forState:UIControlStateNormal];
     self.button.accessibilityLabel = @"Return to LiveContainer";
     self.button.accessibilityHint = @"Minimizes this guest without closing it";
+    self.expandedHint = self.button.accessibilityHint;
     __weak typeof(self) weakControl = self;
     self.button.menu = [UIMenu menuWithTitle:@"" children:@[
-        [UIAction actionWithTitle:@"Hide Return Button" image:[UIImage systemImageNamed:@"eye.slash"] identifier:nil handler:^(__kindof UIAction *action) {
-            [NSUserDefaults.lcUserDefaults setBool:YES forKey:@"LCHideReturnControl"];
+        [UIAction actionWithTitle:@"Collapse Return Button" image:[UIImage systemImageNamed:@"sidebar.right"] identifier:nil handler:^(__kindof UIAction *action) {
+            weakControl.collapsed = YES;
+            weakControl.position = CGPointMake(weakControl.position.x < 0.5 ? 0 : 1, weakControl.position.y);
             [weakControl setNeedsLayout];
-            NSLog(@"[LC_RETURN] CONTROL_HIDDEN");
+            NSLog(@"[LC_RETURN] CONTROL_COLLAPSED");
         }]
     ]];
     [self.button addTarget:self action:@selector(tapped) forControlEvents:UIControlEventTouchUpInside];
@@ -82,6 +86,10 @@ CONTROL = GEOMETRY + r'''
     // A 44-point target must not be placed outside a tiny resized window.
     self.button.hidden = [NSUserDefaults.lcUserDefaults boolForKey:@"LCHideReturnControl"] || CGRectIsNull(rect) || rect.size.width < 44 || rect.size.height < 44;
     if (self.button.hidden) return;
+    self.button.accessibilityLabel = self.collapsed ? @"Show Return to LiveContainer" : @"Return to LiveContainer";
+    self.button.accessibilityHint = self.collapsed ? @"Restores the Return button" : self.expandedHint;
+    self.button.backgroundColor = self.collapsed ? UIColor.clearColor : UIColor.secondarySystemBackgroundColor;
+    [self.button setImage:[UIImage systemImageNamed:self.collapsed ? (self.position.x < 0.5 ? @"chevron.compact.right" : @"chevron.compact.left") : @"arrow.uturn.backward.circle.fill"] forState:UIControlStateNormal];
     self.button.bounds = CGRectMake(0, 0, 44, 44);
     self.button.center = CGPointMake(LCReturnAxisCenter(rect.origin.x, rect.size.width, self.position.x),
                                     LCReturnAxisCenter(rect.origin.y, rect.size.height, self.position.y));
@@ -100,6 +108,7 @@ CONTROL = GEOMETRY + r'''
     double spanY = LCReturnAxisCenter(rect.origin.y, rect.size.height, 1) - minY;
     self.position = CGPointMake(spanX > 0 ? MIN(1, MAX(0, (center.x + delta.x - minX) / spanX)) : 0.5,
                                 spanY > 0 ? MIN(1, MAX(0, (center.y + delta.y - minY) / spanY)) : 0.5);
+    if (self.collapsed) self.position = CGPointMake(self.position.x < 0.5 ? 0 : 1, self.position.y);
     [gesture setTranslation:CGPointZero inView:self];
     [self setNeedsLayout];
     [self layoutIfNeeded];
@@ -108,7 +117,15 @@ CONTROL = GEOMETRY + r'''
         NSLog(@"[LC_RETURN] CONTROL_MOVED");
     }
 }
-- (void)tapped { if (self.action) self.action(); }
+- (void)tapped {
+    if (self.collapsed) {
+        self.collapsed = NO;
+        [self setNeedsLayout];
+        NSLog(@"[LC_RETURN] CONTROL_RESTORED");
+        return;
+    }
+    if (self.action) self.action();
+}
 @end
 '''
 

--- a/scripts/patch_guest_return.py
+++ b/scripts/patch_guest_return.py
@@ -1,12 +1,24 @@
-"""Add a host-owned return control to retained LiveProcess scenes."""
+"""Patch the pinned LiveProcess return path; never terminate a preserved guest."""
 from pathlib import Path
 import sys
 
+MARKER = "LC_GUEST_RETURN_V2"
 
-CONTROL = r'''
-// LC_GUEST_RETURN_V1: this view never owns a guest process or scene.
+# Shared by the real control and executable geometry regression tests.
+GEOMETRY = r'''
+static double LCReturnAxisCenter(double origin, double length, double position) {
+    if (!isfinite(origin) || !isfinite(length) || length < 0) return 0;
+    if (!isfinite(position)) position = 0.5;
+    position = fmin(1.0, fmax(0.0, position));
+    double inset = fmin(30.0, length / 2.0);
+    return origin + inset + position * fmax(0.0, length - 2.0 * inset);
+}
+'''
+
+CONTROL = GEOMETRY + r'''
+// LC_GUEST_RETURN_V2: the control owns no guest process or scene.
 @interface LCReturnControl : UIView
-@property(nonatomic) UIButton *button;
+@property(nonatomic, strong) UIButton *button;
 @property(nonatomic, copy) void (^action)(void);
 @property(nonatomic) CGPoint position;
 @property(nonatomic) CGRect keyboardFrame;
@@ -27,7 +39,7 @@ CONTROL = r'''
     self.button.layer.cornerRadius = 22;
     [self.button setImage:[UIImage systemImageNamed:@"arrow.uturn.backward.circle.fill"] forState:UIControlStateNormal];
     self.button.accessibilityLabel = @"Return to LiveContainer";
-    self.button.accessibilityHint = @"Keeps the guest open when supported";
+    self.button.accessibilityHint = @"Minimizes this guest without closing it";
     [self.button addTarget:self action:@selector(tapped) forControlEvents:UIControlEventTouchUpInside];
     [self.button addGestureRecognizer:[[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(drag:)]];
     [self addSubview:self.button];
@@ -43,22 +55,28 @@ CONTROL = r'''
 }
 - (CGRect)availableRect {
     CGRect rect = UIEdgeInsetsInsetRect(self.bounds, self.safeAreaInsets);
+    if (self.window) {
+        CGRect windowSafe = UIEdgeInsetsInsetRect(self.window.bounds, self.window.safeAreaInsets);
+        CGRect intersection = CGRectIntersection(rect, [self convertRect:windowSafe fromView:self.window]);
+        if (!CGRectIsNull(intersection)) rect = intersection;
+    }
     if (!CGRectIsEmpty(self.keyboardFrame) && self.window) {
         CGRect keyboard = [self convertRect:self.keyboardFrame fromCoordinateSpace:self.window.screen.coordinateSpace];
         if (CGRectIntersectsRect(rect, keyboard) && CGRectGetMaxY(keyboard) >= CGRectGetMaxY(rect)) {
             rect.size.height = MAX(0, CGRectGetMinY(keyboard) - CGRectGetMinY(rect));
         }
     }
-    rect = CGRectInset(rect, 30, 30);
-    rect.size.width = MAX(0, rect.size.width);
-    rect.size.height = MAX(0, rect.size.height);
     return rect;
 }
 - (void)layoutSubviews {
     [super layoutSubviews];
     CGRect rect = [self availableRect];
+    // A 44-point target must not be placed outside a tiny resized window.
+    self.button.hidden = CGRectIsNull(rect) || rect.size.width < 44 || rect.size.height < 44;
+    if (self.button.hidden) return;
     self.button.bounds = CGRectMake(0, 0, 44, 44);
-    self.button.center = CGPointMake(rect.origin.x + self.position.x * rect.size.width, rect.origin.y + self.position.y * rect.size.height);
+    self.button.center = CGPointMake(LCReturnAxisCenter(rect.origin.x, rect.size.width, self.position.x),
+                                    LCReturnAxisCenter(rect.origin.y, rect.size.height, self.position.y));
 }
 - (void)keyboard:(NSNotification *)note {
     self.keyboardFrame = [note.name isEqualToString:UIKeyboardWillHideNotification] ? CGRectZero : [note.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
@@ -68,8 +86,12 @@ CONTROL = r'''
     CGRect rect = [self availableRect];
     CGPoint delta = [gesture translationInView:self];
     CGPoint center = self.button.center;
-    self.position = CGPointMake(rect.size.width > 0 ? MIN(1, MAX(0, (center.x + delta.x - rect.origin.x) / rect.size.width)) : 0.5,
-                                rect.size.height > 0 ? MIN(1, MAX(0, (center.y + delta.y - rect.origin.y) / rect.size.height)) : 0.5);
+    double minX = LCReturnAxisCenter(rect.origin.x, rect.size.width, 0);
+    double minY = LCReturnAxisCenter(rect.origin.y, rect.size.height, 0);
+    double spanX = LCReturnAxisCenter(rect.origin.x, rect.size.width, 1) - minX;
+    double spanY = LCReturnAxisCenter(rect.origin.y, rect.size.height, 1) - minY;
+    self.position = CGPointMake(spanX > 0 ? MIN(1, MAX(0, (center.x + delta.x - minX) / spanX)) : 0.5,
+                                spanY > 0 ? MIN(1, MAX(0, (center.y + delta.y - minY) / spanY)) : 0.5);
     [gesture setTranslation:CGPointZero inView:self];
     [self setNeedsLayout];
     [self layoutIfNeeded];
@@ -105,8 +127,7 @@ METHODS = r'''
     }
     if ([self.delegate isKindOfClass:DecoratedAppSceneViewController.class]) {
         [(DecoratedAppSceneViewController *)self.delegate minimizeWindow];
-        NSLog(@"[LC_RETURN] GUEST_MINIMIZED mode=LIVEPROCESS_PRESERVED_RETURN pid=%d", self.pid);
-        // Minimize's animation reveals the existing host; it does not suspend the guest.
+        NSLog(@"[LC_RETURN] GUEST_MINIMIZE_REQUESTED mode=LIVEPROCESS_PRESERVED_RETURN pid=%d", self.pid);
     } else if (self.lcActivateHost) {
         self.lcActivateHost();
     } else {
@@ -115,67 +136,270 @@ METHODS = r'''
 }
 '''
 
+# Kept in the existing window registry. A generation key prevents an old scene
+# from receiving a new launch callback or being mistaken for a cold launch.
+WINDOW_MANAGER = r'''
+    // LC_GUEST_RETURN_V2: all registry mutations occur on the main queue.
+    static var mainSceneSession: UISceneSession?
 
-def change(root, relative, old, new):
-    path = root / relative
-    text = path.read_text(encoding="utf-8")
-    if new in text:
-        return
+    static func activateMainScene(create: () -> Void) {
+        if let session = mainSceneSession,
+           UIApplication.shared.openSessions.contains(where: { $0.persistentIdentifier == session.persistentIdentifier }) {
+            UIApplication.shared.requestSceneSessionActivation(session, userActivity: nil, options: nil) { error in
+                print("[LC_RETURN] RETURN_FAILED reason=host_activation error=\(error.localizedDescription)")
+            }
+        } else {
+            mainSceneSession = nil
+            create()
+        }
+        // A request is not proof of a foreground transition.
+        print("[LC_RETURN] HOST_ACTIVATION_REQUESTED mode=LIVEPROCESS_PRESERVED_RETURN")
+    }
+
+    @objc class func openAppWindow(displayName: String, dataUUID: String, bundleId: String, pidCallback: ((NSNumber, Error?) -> Void)?) {
+        if !Thread.isMainThread {
+            DispatchQueue.main.async { openAppWindow(displayName: displayName, dataUUID: dataUUID, bundleId: bundleId, pidCallback: pidCallback) }
+            return
+        }
+        guard !appDict.values.contains(where: { $0.dataUUID == dataUUID }) else {
+            pidCallback?(NSNumber(value: -1), NSError(domain: "LiveContainerReturn", code: 409,
+                userInfo: [NSLocalizedDescriptionKey: "This guest container already has a window or a pending launch. Reopen it instead."]))
+            return
+        }
+        DataManager.shared.model.enableMultipleWindow = true
+        var entry = MultitaskAppInfo(displayName: displayName, dataUUID: dataUUID, bundleId: bundleId)
+        entry.launchCallback = pidCallback
+        appDict[entry.windowID] = entry
+        openWindow(id: "appView", value: entry.windowID)
+    }
+
+    static func bind(_ controller: AppSceneViewController, windowID: String) {
+        guard appDict[windowID] != nil else { return }
+        appDict[windowID]?.controller = controller
+    }
+
+    static func initialized(_ controller: AppSceneViewController, windowID: String, error: Error?) {
+        guard var entry = appDict[windowID] else { return }
+        entry.controller = controller
+        entry.pid = controller.pid
+        let callback = entry.launchCallback
+        entry.launchCallback = nil // Consume before calling re-entrant client code.
+        appDict[windowID] = entry
+        if error != nil {
+            controller.appTerminationCleanUp()
+            appDict.removeValue(forKey: windowID)
+        }
+        callback?(NSNumber(value: controller.pid), error)
+    }
+
+    static func exited(_ controller: AppSceneViewController, windowID: String) {
+        guard let entry = appDict[windowID], entry.controller === controller else { return }
+        appDict.removeValue(forKey: windowID)
+        entry.launchCallback?(NSNumber(value: -1), NSError(domain: "LiveContainerReturn", code: 410,
+            userInfo: [NSLocalizedDescriptionKey: "The guest exited before its launch completed."]))
+        print("[LC_RETURN] STALE_GUEST_CLEANED");
+    }
+
+    @objc class func openExistingAppWindow(dataUUID: String) -> Bool {
+        if !Thread.isMainThread {
+            return DispatchQueue.main.sync { openExistingAppWindow(dataUUID: dataUUID) }
+        }
+        for (key, entry) in Array(appDict) where entry.dataUUID == dataUUID {
+            if let controller = entry.controller {
+                if !controller.isAppRunning && controller.pid > 0 {
+                    // Cleanup on main completes before another launch can register.
+                    controller.appTerminationCleanUp()
+                    appDict.removeValue(forKey: key)
+                    print("[LC_RETURN] STALE_GUEST_CLEANED")
+                    continue
+                }
+            } else if entry.pid > 0 {
+                // Missing scene ownership is not a verified resume. Do not touch
+                // container registration; the model's in-use check prevents duplicates.
+                appDict.removeValue(forKey: key)
+                print("[LC_RETURN] RETURN_FAILED reason=retained_controller_missing")
+                continue
+            }
+            openWindow(id: "appView", value: key)
+            print(entry.pid > 0 ? "[LC_RETURN] GUEST_RESUMED_EXISTING" : "[LC_RETURN] GUEST_LAUNCH_PENDING")
+            return true
+        }
+        return false
+    }
+'''
+
+DOCK_RESUME = r'''
+    func bringMultitaskViewToFront(uuid: String, from center: CGPoint? = nil) -> Bool {
+        guard let targetView = apps.first(where: { $0.appUUID == uuid })?.view,
+              let controller = targetView._viewDelegate() as? DecoratedAppSceneViewController else { return false }
+        if !controller.appSceneVC.isAppRunning && controller.appSceneVC.pid > 0 {
+            controller.appSceneVC.appTerminationCleanUp()
+            // Upstream may intentionally retain the terminated-screen row.
+            // Remove that exact old row before registering its replacement.
+            removeRunningApp(uuid)
+            controller.willMove(toParent: nil)
+            targetView.removeFromSuperview()
+            controller.removeFromParent()
+            print("[LC_RETURN] STALE_GUEST_CLEANED")
+            return false
+        }
+        guard let window = targetView.window else {
+            print("[LC_RETURN] RETURN_FAILED reason=retained_view_has_no_window")
+            return false
+        }
+        passURLSchemeToView(targetView)
+        animateViewAppearance(targetView, from: center, in: window)
+        print(controller.appSceneVC.pid > 0 ? "[LC_RETURN] GUEST_RESUMED_EXISTING" : "[LC_RETURN] GUEST_LAUNCH_PENDING")
+        return true
+    }
+'''
+
+CLEANUP = r'''
+- (void)appTerminationCleanUp {
+    if (!NSThread.isMainThread) {
+        dispatch_async(dispatch_get_main_queue(), ^{ [self appTerminationCleanUp]; });
+        return;
+    }
+    if (_isAppTerminationCleanUpCalled) return;
+    _isAppTerminationCleanUpCalled = true;
+    self.lcReturnControl.hidden = YES;
+    if (self.sceneID) {
+        [[PrivClass(FBSceneManager) sharedInstance] destroyScene:self.sceneID withTransitionContext:nil];
+    }
+    if (self.usesHostingControllerAPI) {
+        if (@available(iOS 17.0, *)) {
+            [self.hostingController invalidate];
+            [self.hostingController.sceneViewController removeFromParentViewController];
+            self.hostingController = nil;
+        }
+    } else if (self.presenter) {
+        [self.presenter deactivate];
+        [self.presenter invalidate];
+    }
+    self.presenter = nil;
+    // Release the old registration BEFORE notifying code that may relaunch.
+    [MultitaskManager unregisterMultitaskContainerWithContainer:self.dataUUID];
+    [self.delegate appSceneVCAppDidExit:self];
+}
+'''
+
+PATHS = (
+    "MultitaskSupport/AppSceneViewController.m", "MultitaskSupport/AppSceneViewController.h",
+    "MultitaskSupport/MultitaskAppWindow.swift", "MultitaskSupport/MultitaskDockView.swift",
+    "SideStoreSupport/SideStoreHooks.m", "LiveContainerSwiftUI/Models/LCAppModel.swift",
+    "LiveContainerSwiftUI/Views/LCTabView.swift",
+)
+
+
+def replace(text, old, new, label):
     if text.count(old) != 1:
-        raise ValueError(f"Changed upstream anchor: {relative}: {old[:80]}")
-    path.write_text(text.replace(old, new, 1), encoding="utf-8")
+        raise ValueError(f"Changed upstream anchor: {label}: {old[:100]}")
+    return text.replace(old, new, 1)
+
+
+def section(text, start, end, replacement, label):
+    if text.count(start) != 1 or text.count(end) != 1:
+        raise ValueError(f"Changed upstream section: {label}")
+    a = text.index(start)
+    b = text.index(end, a)
+    return text[:a] + replacement + "\n\n" + text[b:]
+
+
+def verify(texts):
+    implementation, header, window, dock, hooks, model, tab = (texts[p] for p in PATHS)
+    for text, token in ((implementation, CONTROL), (implementation, METHODS), (implementation, CLEANUP),
+                        (window, WINDOW_MANAGER), (dock, DOCK_RESUME), (header, "lcActivateHost"),
+                        (hooks, "DIRECT_PROCESS_RESTART_RETURN"), (model, "LC_RETURN_CONTAINER_GUARD"),
+                        (tab, "MultitaskWindowManager.mainSceneSession")):
+        if token.strip() not in text:
+            raise ValueError("Incomplete guest-return patch: " + token[:65])
+    if "DataManager.shared.model.pidCallback" in window:
+        raise ValueError("Global cross-window callback survived")
 
 
 def patch(root):
-    implementation = "MultitaskSupport/AppSceneViewController.m"
-    change(root, implementation, "@property int resizeDebounceToken;", "@property(nonatomic) LCReturnControl *lcReturnControl;\n@property int resizeDebounceToken;")
-    change(root, implementation, '#import "UIKitPrivate+MultitaskSupport.h"', '#import "UIKitPrivate+MultitaskSupport.h"\n#include <math.h>\n' + CONTROL)
-    change(root, implementation, "@implementation AppSceneViewController", "@implementation AppSceneViewController\n" + METHODS)
-    change(root, "MultitaskSupport/AppSceneViewController.h", "- (void)terminate;", "@property(nonatomic, copy) void (^lcActivateHost)(void);\n- (void)terminate;")
-    window = "MultitaskSupport/MultitaskAppWindow.swift"
-    change(root, window, "    @Binding var show: Bool", '    @Environment(\\.openWindow) private var returnOpenWindow\n    @Binding var show: Bool')
-    change(root, window, "        return AppSceneViewController(bundleId: bundleId, dataUUID: dataUUID, delegate: context.coordinator)", '''        let controller = AppSceneViewController(bundleId: bundleId, dataUUID: dataUUID, delegate: context.coordinator)
-        guard let controller else {
+    root = Path(root)
+    texts = {p: (root / p).read_text(encoding="utf-8") for p in PATHS}
+    implementation, header, window, dock, hooks, model, tab = (texts[p] for p in PATHS)
+    if MARKER in implementation:
+        verify(texts)
+        return
+    if "LC_GUEST_RETURN_V1" in implementation:
+        raise ValueError("Reapply the return patch to clean pinned sources, not a V1-patched tree")
+
+    implementation = replace(implementation, '#import "UIKitPrivate+MultitaskSupport.h"',
+                             '#import "UIKitPrivate+MultitaskSupport.h"\n#include <math.h>\n' + CONTROL, "control")
+    implementation = replace(implementation, "@property int resizeDebounceToken;", "@property(nonatomic, strong) LCReturnControl *lcReturnControl;\n@property int resizeDebounceToken;", "control property")
+    implementation = replace(implementation, "@implementation AppSceneViewController", "@implementation AppSceneViewController\n" + METHODS, "return method")
+    implementation = replace(implementation, "    [self.view addSubview:_contentView];", "    [self.view addSubview:_contentView];\n    [self.view setNeedsLayout]; // Re-show control after asynchronous guest initialization.", "control readiness")
+    implementation = replace(implementation, "return _pid > 0 && getpgid(_pid) > 0;", "return !_isAppTerminationCleanUpCalled && _pid > 0 && getpgid(_pid) > 0;", "retired process is not resumable")
+    implementation = section(implementation, "- (void)appTerminationCleanUp {", "- (void)setBackgroundNotificationEnabled:", CLEANUP, "synchronous cleanup")
+    implementation = replace(implementation, "- (void)setUpAppPresenter {", "- (void)setUpAppPresenter {\n    if (_isAppTerminationCleanUpCalled || !self.isAppRunning) {\n        [self appTerminationCleanUp];\n        return;\n    }", "cancelled guest cannot create a scene")
+    request_start = "    [_extension beginExtensionRequestWithInputItems:@[item] completion:^(NSUUID *identifier) {"
+    a = implementation.index(request_start)
+    b = implementation.index("\n    return self;", a)
+    request = implementation[a:b]
+    if request.count("    }];") != 1:
+        raise ValueError("Changed extension launch completion boundary")
+    updated_request = request.replace(request_start, request_start + "\n        dispatch_async(dispatch_get_main_queue(), ^{\n            if (self.isAppTerminationCleanUpCalled) return;", 1)
+    updated_request = updated_request.replace("    }];", "        });\n    }];", 1)
+    implementation = implementation[:a] + updated_request + implementation[b:]
+
+    header = replace(header, "- (void)terminate;", "@property(nonatomic, copy) void (^lcActivateHost)(void);\n- (void)terminate;", "host action")
+
+    window = replace(window, "    var bundleId: String\n", "    var bundleId: String\n    let windowID = UUID().uuidString\n    var pid: Int32 = 0\n    weak var controller: AppSceneViewController?\n    var launchCallback: ((NSNumber, Error?) -> Void)?\n", "per-window launch identity")
+    window = section(window, "    @objc class func openAppWindow(", "\n}\n\n@available(iOS 16.1, *)\nstruct AppSceneViewSwiftUI", WINDOW_MANAGER, "window registry")
+    window = replace(window, "    @Binding var show: Bool", '    @Environment(\\.openWindow) private var returnOpenWindow\n    let windowID: String\n    @Binding var show: Bool', "window action")
+    window = replace(window, "        let onExit: () -> Void", "        let windowID: String\n        let onExit: () -> Void", "coordinator identity")
+    window = replace(window, "        init(onAppInitialize: @escaping (Int32, Error?) -> Void, onExit: @escaping () -> Void) {", "        init(windowID: String, onAppInitialize: @escaping (Int32, Error?) -> Void, onExit: @escaping () -> Void) {\n            self.windowID = windowID", "coordinator init")
+    window = replace(window, "        func appSceneVCAppDidExit(_: AppSceneViewController!) {\n            onExit()\n        }", "        func appSceneVCAppDidExit(_ vc: AppSceneViewController!) {\n            MultitaskWindowManager.exited(vc, windowID: windowID)\n            onExit()\n        }", "window exit")
+    window = replace(window, "            onAppInitialize(vc.pid, error)", "            DispatchQueue.main.async {\n                MultitaskWindowManager.initialized(vc, windowID: self.windowID, error: error)\n                self.onAppInitialize(vc.pid, error)\n            }", "launch completion")
+    window = replace(window, "        Coordinator(onAppInitialize: onAppInitialize, onExit: {", "        Coordinator(windowID: windowID, onAppInitialize: onAppInitialize, onExit: {", "make coordinator")
+    window = replace(window, "        return AppSceneViewController(bundleId: bundleId, dataUUID: dataUUID, delegate: context.coordinator)", '''        guard let controller = AppSceneViewController(bundleId: bundleId, dataUUID: dataUUID, delegate: context.coordinator) else {
             print("[LC_RETURN] RETURN_FAILED reason=guest_controller_initialization_failed")
             return UIViewController()
         }
+        MultitaskWindowManager.bind(controller, windowID: windowID)
         controller.lcActivateHost = {
-            print("[LC_RETURN] HOST_ACTIVATION_REQUESTED mode=LIVEPROCESS_PRESERVED_RETURN")
-            returnOpenWindow(id: "Main")
+            MultitaskWindowManager.activateMainScene(create: { returnOpenWindow(id: "Main") })
         }
-        return controller
-'''.rstrip())
-    model = "LiveContainerSwiftUI/Models/LCAppModel.swift"
-    change(root, window, "    var bundleId: String\n", "    var bundleId: String\n    var pid: Int32 = 0\n")
-    change(root, window, "            if a.value.dataUUID == dataUUID {", '''            if a.value.dataUUID == dataUUID {
-                if a.value.pid > 0 && getpgid(a.value.pid) <= 0 {
-                    appDict.removeValue(forKey: a.key)
-                    MultitaskManager.unregisterMultitaskContainer(container: dataUUID)
-                    print("[LC_RETURN] STALE_GUEST_CLEANED")
-                    return false
-                }''')
-    change(root, window, "                            self.pid = Int(pid)", "                            self.pid = Int(pid)\n                            MultitaskWindowManager.appDict[appInfo.dataUUID]?.pid = pid")
-    dock = "MultitaskSupport/MultitaskDockView.swift"
-    change(root, dock, '''        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
-            return false
-        }
+        return controller''', "make controller")
+    window = replace(window, "AppSceneViewSwiftUI(show: $show,", "AppSceneViewSwiftUI(windowID: appInfo.windowID, show: $show,", "pass window identity")
+    window = replace(window, "                        DataManager.shared.model.pidCallback?(NSNumber(value: pid), error)\n                        DataManager.shared.model.pidCallback = nil\n", "", "remove global callback")
 
-        for window in windowScene.windows {''', '''        let windows = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.flatMap { $0.windows }
-        for window in windows {''')
-    change(root, dock, "                passURLSchemeToView(targetView)", '''                if let controller = targetView._viewDelegate() as? DecoratedAppSceneViewController,
-                   !controller.appSceneVC.isAppRunning {
-                    controller.appSceneVC.appTerminationCleanUp()
-                    print("[LC_RETURN] STALE_GUEST_CLEANED")
-                    return false
-                }
-                passURLSchemeToView(targetView)''')
-    change(root, model, "            return found\n", '''            print(found ? "[LC_RETURN] GUEST_RESUMED_EXISTING" : "[LC_RETURN] GUEST_COLD_LAUNCH")
-            return found
-''')
-    change(root, model, "    private func bringExistingMultitaskWindowIfNeeded(dataUUID: String, urlScheme: String?) async -> Bool {", "    private func bringExistingMultitaskWindowIfNeeded(dataUUID: String, urlScheme: String?) async -> Bool {\n        print(\"[LC_RETURN] GUEST_RESUME_REQUESTED\")")
-    hooks = "SideStoreSupport/SideStoreHooks.m"
-    change(root, hooks, "    [LCSharedUtils launchToGuestAppWithClassicMode:0];", '    NSLog(@"[LC_RETURN] MODE_DIRECT mode=DIRECT_PROCESS_RESTART_RETURN");\n    [LCSharedUtils launchToGuestAppWithClassicMode:0];')
+    dock = section(dock, "    func bringMultitaskViewToFront(uuid:", "    private func passURLSchemeToView(", DOCK_RESUME, "resume owning window")
+    dock = section(dock, "    @objc public func removeRunningApp(", "    @objc public func showDock()", '''    @objc public func removeRunningApp(_ appUUID: String) {
+        if !Thread.isMainThread {
+            DispatchQueue.main.async { self.removeRunningApp(appUUID) }
+            return
+        }
+        self.apps.removeAll { $0.appUUID == appUUID }
+        if self.apps.isEmpty { self.hideDock() }
+        else if self.isVisible { self.updateDockFrame() }
+    }''', "remove stale dock entry synchronously")
+
+    model = replace(model, "            return found\n", '            if !found { print("[LC_RETURN] GUEST_COLD_LAUNCH_REQUIRED") }\n            return found\n', "honest resume diagnostics")
+    model = replace(model, "    private func bringExistingMultitaskWindowIfNeeded(dataUUID: String, urlScheme: String?) async -> Bool {", '    private func bringExistingMultitaskWindowIfNeeded(dataUUID: String, urlScheme: String?) async -> Bool {\n        print("[LC_RETURN] GUEST_RESUME_REQUESTED")', "resume diagnostics")
+    model = replace(model, '''            if await bringExistingMultitaskWindowIfNeeded(dataUUID: currentDataFolder, urlScheme: urlStr) {
+                return
+            }''', '''            if await bringExistingMultitaskWindowIfNeeded(dataUUID: currentDataFolder, urlScheme: urlStr) {
+                return
+            }
+            // LC_RETURN_CONTAINER_GUARD: failed scene lookup must not duplicate a live container.
+            if await MainActor.run(body: { MultitaskManager.isUsing(container: currentDataFolder) }) {
+                throw "lc.container.inUse".loc + "\\nA retained guest still owns this container. Close its existing window before relaunching."
+            }''', "container ownership")
+    hooks = replace(hooks, "    [LCSharedUtils launchToGuestAppWithClassicMode:0];", '    NSLog(@"[LC_RETURN] MODE_DIRECT mode=DIRECT_PROCESS_RESTART_RETURN");\n    [LCSharedUtils launchToGuestAppWithClassicMode:0];', "direct fallback diagnostic")
+    tab = replace(tab, "            shouldToggleMainWindowOpen = true\n", "            shouldToggleMainWindowOpen = true\n            if #available(iOS 16.1, *) {\n                MultitaskWindowManager.mainSceneSession = sceneDelegate.window?.windowScene?.session\n            }\n", "capture real main scene")
+    tab = replace(tab, "                    DataManager.shared.model.mainWindowOpened = false", "                    DataManager.shared.model.mainWindowOpened = false\n                    if #available(iOS 16.1, *), MultitaskWindowManager.mainSceneSession?.persistentIdentifier == scene1.session.persistentIdentifier {\n                        MultitaskWindowManager.mainSceneSession = nil\n                    }", "clear disconnected main scene")
+    updated = dict(zip(PATHS, (implementation, header, window, dock, hooks, model, tab)))
+    verify(updated)
+    # Validate every anchor before writing any file, so upstream drift is not a partial patch.
+    for relative, text in updated.items():
+        (root / relative).write_text(text, encoding="utf-8")
 
 
 if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: patch_guest_return.py <pinned-livecontainer-root>")
     patch(Path(sys.argv[1]))

--- a/scripts/patch_guest_return.py
+++ b/scripts/patch_guest_return.py
@@ -1,0 +1,181 @@
+"""Add a host-owned return control to retained LiveProcess scenes."""
+from pathlib import Path
+import sys
+
+
+CONTROL = r'''
+// LC_GUEST_RETURN_V1: this view never owns a guest process or scene.
+@interface LCReturnControl : UIView
+@property(nonatomic) UIButton *button;
+@property(nonatomic, copy) void (^action)(void);
+@property(nonatomic) CGPoint position;
+@property(nonatomic) CGRect keyboardFrame;
+@end
+@implementation LCReturnControl
+- (instancetype)initWithFrame:(CGRect)frame {
+    if (!(self = [super initWithFrame:frame])) return nil;
+    self.backgroundColor = UIColor.clearColor;
+    self.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    NSArray *saved = [NSUserDefaults.lcUserDefaults arrayForKey:@"LCReturnControlPosition"];
+    self.position = CGPointMake(0.95, 0.25);
+    if (saved.count == 2 && [saved[0] isKindOfClass:NSNumber.class] && [saved[1] isKindOfClass:NSNumber.class]) {
+        double x = [saved[0] doubleValue], y = [saved[1] doubleValue];
+        if (isfinite(x) && isfinite(y) && x >= 0 && x <= 1 && y >= 0 && y <= 1) self.position = CGPointMake(x, y);
+    }
+    self.button = [UIButton buttonWithType:UIButtonTypeSystem];
+    self.button.backgroundColor = UIColor.secondarySystemBackgroundColor;
+    self.button.layer.cornerRadius = 22;
+    [self.button setImage:[UIImage systemImageNamed:@"arrow.uturn.backward.circle.fill"] forState:UIControlStateNormal];
+    self.button.accessibilityLabel = @"Return to LiveContainer";
+    self.button.accessibilityHint = @"Keeps the guest open when supported";
+    [self.button addTarget:self action:@selector(tapped) forControlEvents:UIControlEventTouchUpInside];
+    [self.button addGestureRecognizer:[[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(drag:)]];
+    [self addSubview:self.button];
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(keyboard:) name:UIKeyboardWillChangeFrameNotification object:nil];
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(keyboard:) name:UIKeyboardWillHideNotification object:nil];
+    NSLog(@"[LC_RETURN] CONTROL_SHOWN");
+    return self;
+}
+- (void)dealloc { [NSNotificationCenter.defaultCenter removeObserver:self]; }
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    UIView *hit = [super hitTest:point withEvent:event];
+    return hit == self ? nil : hit;
+}
+- (CGRect)availableRect {
+    CGRect rect = UIEdgeInsetsInsetRect(self.bounds, self.safeAreaInsets);
+    if (!CGRectIsEmpty(self.keyboardFrame) && self.window) {
+        CGRect keyboard = [self convertRect:self.keyboardFrame fromCoordinateSpace:self.window.screen.coordinateSpace];
+        if (CGRectIntersectsRect(rect, keyboard) && CGRectGetMaxY(keyboard) >= CGRectGetMaxY(rect)) {
+            rect.size.height = MAX(0, CGRectGetMinY(keyboard) - CGRectGetMinY(rect));
+        }
+    }
+    rect = CGRectInset(rect, 30, 30);
+    rect.size.width = MAX(0, rect.size.width);
+    rect.size.height = MAX(0, rect.size.height);
+    return rect;
+}
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGRect rect = [self availableRect];
+    self.button.bounds = CGRectMake(0, 0, 44, 44);
+    self.button.center = CGPointMake(rect.origin.x + self.position.x * rect.size.width, rect.origin.y + self.position.y * rect.size.height);
+}
+- (void)keyboard:(NSNotification *)note {
+    self.keyboardFrame = [note.name isEqualToString:UIKeyboardWillHideNotification] ? CGRectZero : [note.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+    [self setNeedsLayout];
+}
+- (void)drag:(UIPanGestureRecognizer *)gesture {
+    CGRect rect = [self availableRect];
+    CGPoint delta = [gesture translationInView:self];
+    CGPoint center = self.button.center;
+    self.position = CGPointMake(rect.size.width > 0 ? MIN(1, MAX(0, (center.x + delta.x - rect.origin.x) / rect.size.width)) : 0.5,
+                                rect.size.height > 0 ? MIN(1, MAX(0, (center.y + delta.y - rect.origin.y) / rect.size.height)) : 0.5);
+    [gesture setTranslation:CGPointZero inView:self];
+    [self setNeedsLayout];
+    [self layoutIfNeeded];
+    if (gesture.state == UIGestureRecognizerStateEnded || gesture.state == UIGestureRecognizerStateCancelled) {
+        [NSUserDefaults.lcUserDefaults setObject:@[@(self.position.x), @(self.position.y)] forKey:@"LCReturnControlPosition"];
+        NSLog(@"[LC_RETURN] CONTROL_MOVED");
+    }
+}
+- (void)tapped { if (self.action) self.action(); }
+@end
+'''
+
+METHODS = r'''
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    if (!self.lcReturnControl) {
+        self.lcReturnControl = [[LCReturnControl alloc] initWithFrame:self.view.bounds];
+        __weak typeof(self) weakSelf = self;
+        self.lcReturnControl.action = ^{ [weakSelf lcReturnToHost]; };
+        [self.view addSubview:self.lcReturnControl];
+    }
+    self.lcReturnControl.frame = self.view.bounds;
+    self.lcReturnControl.hidden = !self.isAppRunning;
+    [self.view bringSubviewToFront:self.lcReturnControl];
+}
+- (void)lcReturnToHost {
+    NSLog(@"[LC_RETURN] RETURN_REQUESTED pid=%d", self.pid);
+    NSLog(@"[LC_RETURN] MODE_LIVEPROCESS");
+    if (!self.isAppRunning) {
+        NSLog(@"[LC_RETURN] RETURN_FAILED reason=guest_exited");
+        [self appTerminationCleanUp];
+        return;
+    }
+    if ([self.delegate isKindOfClass:DecoratedAppSceneViewController.class]) {
+        [(DecoratedAppSceneViewController *)self.delegate minimizeWindow];
+        NSLog(@"[LC_RETURN] GUEST_MINIMIZED mode=LIVEPROCESS_PRESERVED_RETURN pid=%d", self.pid);
+        // Minimize's animation reveals the existing host; it does not suspend the guest.
+    } else if (self.lcActivateHost) {
+        self.lcActivateHost();
+    } else {
+        NSLog(@"[LC_RETURN] RETURN_FAILED reason=host_activation_unavailable");
+    }
+}
+'''
+
+
+def change(root, relative, old, new):
+    path = root / relative
+    text = path.read_text(encoding="utf-8")
+    if new in text:
+        return
+    if text.count(old) != 1:
+        raise ValueError(f"Changed upstream anchor: {relative}: {old[:80]}")
+    path.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+
+def patch(root):
+    implementation = "MultitaskSupport/AppSceneViewController.m"
+    change(root, implementation, "@property int resizeDebounceToken;", "@property(nonatomic) LCReturnControl *lcReturnControl;\n@property int resizeDebounceToken;")
+    change(root, implementation, '#import "UIKitPrivate+MultitaskSupport.h"', '#import "UIKitPrivate+MultitaskSupport.h"\n#include <math.h>\n' + CONTROL)
+    change(root, implementation, "@implementation AppSceneViewController", "@implementation AppSceneViewController\n" + METHODS)
+    change(root, "MultitaskSupport/AppSceneViewController.h", "- (void)terminate;", "@property(nonatomic, copy) void (^lcActivateHost)(void);\n- (void)terminate;")
+    window = "MultitaskSupport/MultitaskAppWindow.swift"
+    change(root, window, "    @Binding var show: Bool", '    @Environment(\\.openWindow) private var returnOpenWindow\n    @Binding var show: Bool')
+    change(root, window, "        return AppSceneViewController(bundleId: bundleId, dataUUID: dataUUID, delegate: context.coordinator)", '''        let controller = AppSceneViewController(bundleId: bundleId, dataUUID: dataUUID, delegate: context.coordinator)
+        guard let controller else {
+            print("[LC_RETURN] RETURN_FAILED reason=guest_controller_initialization_failed")
+            return UIViewController()
+        }
+        controller.lcActivateHost = {
+            print("[LC_RETURN] HOST_ACTIVATION_REQUESTED mode=LIVEPROCESS_PRESERVED_RETURN")
+            returnOpenWindow(id: "Main")
+        }
+        return controller
+'''.rstrip())
+    model = "LiveContainerSwiftUI/Models/LCAppModel.swift"
+    change(root, window, "    var bundleId: String\n", "    var bundleId: String\n    var pid: Int32 = 0\n")
+    change(root, window, "            if a.value.dataUUID == dataUUID {", '''            if a.value.dataUUID == dataUUID {
+                if a.value.pid > 0 && getpgid(a.value.pid) <= 0 {
+                    appDict.removeValue(forKey: a.key)
+                    MultitaskManager.unregisterMultitaskContainer(container: dataUUID)
+                    print("[LC_RETURN] STALE_GUEST_CLEANED")
+                    return false
+                }''')
+    change(root, window, "                            self.pid = Int(pid)", "                            self.pid = Int(pid)\n                            MultitaskWindowManager.appDict[appInfo.dataUUID]?.pid = pid")
+    dock = "MultitaskSupport/MultitaskDockView.swift"
+    change(root, dock, '''        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
+            return false
+        }
+
+        for window in windowScene.windows {''', '''        let windows = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.flatMap { $0.windows }
+        for window in windows {''')
+    change(root, dock, "                passURLSchemeToView(targetView)", '''                if let controller = targetView._viewDelegate() as? DecoratedAppSceneViewController,
+                   !controller.appSceneVC.isAppRunning {
+                    controller.appSceneVC.appTerminationCleanUp()
+                    print("[LC_RETURN] STALE_GUEST_CLEANED")
+                    return false
+                }
+                passURLSchemeToView(targetView)''')
+    change(root, model, "            return found\n", '''            print(found ? "[LC_RETURN] GUEST_RESUMED_EXISTING" : "[LC_RETURN] GUEST_COLD_LAUNCH")
+            return found
+''')
+    change(root, model, "    private func bringExistingMultitaskWindowIfNeeded(dataUUID: String, urlScheme: String?) async -> Bool {", "    private func bringExistingMultitaskWindowIfNeeded(dataUUID: String, urlScheme: String?) async -> Bool {\n        print(\"[LC_RETURN] GUEST_RESUME_REQUESTED\")")
+    hooks = "SideStoreSupport/SideStoreHooks.m"
+    change(root, hooks, "    [LCSharedUtils launchToGuestAppWithClassicMode:0];", '    NSLog(@"[LC_RETURN] MODE_DIRECT mode=DIRECT_PROCESS_RESTART_RETURN");\n    [LCSharedUtils launchToGuestAppWithClassicMode:0];')
+
+
+if __name__ == "__main__":
+    patch(Path(sys.argv[1]))

--- a/scripts/patch_guest_return.py
+++ b/scripts/patch_guest_return.py
@@ -13,6 +13,9 @@ static double LCReturnAxisCenter(double origin, double length, double position) 
     double inset = fmin(30.0, length / 2.0);
     return origin + inset + position * fmax(0.0, length - 2.0 * inset);
 }
+static int LCReturnShouldHide(int running, int decorated, int maximized) {
+    return !running || (decorated && !maximized);
+}
 '''
 
 CONTROL = GEOMETRY + r'''
@@ -151,7 +154,9 @@ METHODS = r'''
         NSLog(@"[LC_RETURN] CONTROL_ATTACHED layer=%@", overlayHost == self.view ? @"native" : @"virtual_window_chrome");
     }
     self.lcReturnControl.frame = [self.view convertRect:self.view.bounds toView:overlayHost];
-    self.lcReturnControl.hidden = !self.isAppRunning;
+    BOOL decorated = [self.delegate isKindOfClass:DecoratedAppSceneViewController.class];
+    BOOL maximized = decorated && [(DecoratedAppSceneViewController *)self.delegate isMaximized];
+    self.lcReturnControl.hidden = LCReturnShouldHide(self.isAppRunning, decorated, maximized);
     [overlayHost bringSubviewToFront:self.lcReturnControl];
 }
 - (void)lcReturnToHost {
@@ -398,6 +403,7 @@ PATHS = (
     "LiveContainerSwiftUI/Views/LCTabView.swift",
     "LiveContainer/LCBootstrap.m",
     "LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift",
+    "MultitaskSupport/DecoratedAppSceneViewController.m",
 )
 
 
@@ -416,7 +422,7 @@ def section(text, start, end, replacement, label):
 
 
 def verify(texts):
-    implementation, header, window, dock, hooks, model, tab, bootstrap, settings = (texts[p] for p in PATHS)
+    implementation, header, window, dock, hooks, model, tab, bootstrap, settings, decorated = (texts[p] for p in PATHS)
     for text, token in ((implementation, CONTROL), (implementation, METHODS), (implementation, CLEANUP),
                         (window, WINDOW_MANAGER), (dock, DOCK_RESUME), (header, "lcActivateHost"),
                         (hooks, "DIRECT_PROCESS_RESTART_RETURN"), (model, "LC_RETURN_CONTAINER_GUARD"),
@@ -429,12 +435,15 @@ def verify(texts):
         raise ValueError("Incomplete direct guest Return patch")
     if 'Toggle("Show Return Button"' not in settings:
         raise ValueError("Return visibility setting missing")
+    for state in ("YES", "NO"):
+        if f"self.isMaximized = {state};\n            [self.appSceneVC.view setNeedsLayout];" not in decorated:
+            raise ValueError("Return visibility transition missing: " + state)
 
 
 def patch(root):
     root = Path(root)
     texts = {p: (root / p).read_text(encoding="utf-8") for p in PATHS}
-    implementation, header, window, dock, hooks, model, tab, bootstrap, settings = (texts[p] for p in PATHS)
+    implementation, header, window, dock, hooks, model, tab, bootstrap, settings, decorated = (texts[p] for p in PATHS)
     if MARKER in implementation:
         verify(texts)
         return
@@ -513,7 +522,11 @@ def patch(root):
                 Section("Guest Controls") {
                     Toggle("Show Return Button", isOn: Binding(get: { !hideReturnControl }, set: { hideReturnControl = !$0 }))
                 }''', "restore return control")
-    updated = dict(zip(PATHS, (implementation, header, window, dock, hooks, model, tab, bootstrap, settings)))
+    for state in ("YES", "NO"):
+        decorated = replace(decorated, f"self.isMaximized = {state};",
+                            f"self.isMaximized = {state};\n            [self.appSceneVC.view setNeedsLayout];",
+                            "Return visibility on maximize/restore " + state)
+    updated = dict(zip(PATHS, (implementation, header, window, dock, hooks, model, tab, bootstrap, settings, decorated)))
     verify(updated)
     # Validate every anchor before writing any file, so upstream drift is not a partial patch.
     for relative, text in updated.items():

--- a/scripts/patch_guest_return.py
+++ b/scripts/patch_guest_return.py
@@ -478,7 +478,7 @@ def patch(root):
     tab = replace(tab, "                    DataManager.shared.model.mainWindowOpened = false", "                    DataManager.shared.model.mainWindowOpened = false\n                    if #available(iOS 16.1, *), MultitaskWindowManager.mainSceneSession?.persistentIdentifier == scene1.session.persistentIdentifier {\n                        MultitaskWindowManager.mainSceneSession = nil\n                    }", "clear disconnected main scene")
     bootstrap = replace(bootstrap, "extern char **environ;", "#include <math.h>\n" + DIRECT_CONTROL + DIRECT_RUNTIME + "\nextern char **environ;", "direct return presenter")
     bootstrap = replace(bootstrap, "    // Go!", "    // Install before guest UIApplication/scene creation, never inside LiveProcess.\n    if (!isLiveProcess && !isSideStore) {\n        lcDirectReturnPresenter = [LCDirectReturnPresenter new];\n    }\n    // Go!", "direct launch route")
-    settings = replace(settings, "    @State var errorShow = false", '    @AppStorage("LCHideReturnControl", store: UserDefaults.lcUserDefaults()) private var hideReturnControl = false\n    @State var errorShow = false', "visibility preference")
+    settings = replace(settings, "    @State var errorShow = false", '    @AppStorage("LCHideReturnControl", store: UserDefaults.lc()) private var hideReturnControl = false\n    @State var errorShow = false', "visibility preference")
     settings = replace(settings, "            Form {", '''            Form {
                 Section("Guest Controls") {
                     Toggle("Show Return Button", isOn: Binding(get: { !hideReturnControl }, set: { hideReturnControl = !$0 }))

--- a/scripts/patch_guest_return.py
+++ b/scripts/patch_guest_return.py
@@ -478,7 +478,7 @@ def patch(root):
     tab = replace(tab, "                    DataManager.shared.model.mainWindowOpened = false", "                    DataManager.shared.model.mainWindowOpened = false\n                    if #available(iOS 16.1, *), MultitaskWindowManager.mainSceneSession?.persistentIdentifier == scene1.session.persistentIdentifier {\n                        MultitaskWindowManager.mainSceneSession = nil\n                    }", "clear disconnected main scene")
     bootstrap = replace(bootstrap, "extern char **environ;", "#include <math.h>\n" + DIRECT_CONTROL + DIRECT_RUNTIME + "\nextern char **environ;", "direct return presenter")
     bootstrap = replace(bootstrap, "    // Go!", "    // Install before guest UIApplication/scene creation, never inside LiveProcess.\n    if (!isLiveProcess && !isSideStore) {\n        lcDirectReturnPresenter = [LCDirectReturnPresenter new];\n    }\n    // Go!", "direct launch route")
-    settings = replace(settings, "    @State var errorShow = false", '    @AppStorage("LCHideReturnControl", store: UserDefaults.lcUserDefaults) private var hideReturnControl = false\n    @State var errorShow = false', "visibility preference")
+    settings = replace(settings, "    @State var errorShow = false", '    @AppStorage("LCHideReturnControl", store: UserDefaults.lcUserDefaults()) private var hideReturnControl = false\n    @State var errorShow = false', "visibility preference")
     settings = replace(settings, "            Form {", '''            Form {
                 Section("Guest Controls") {
                     Toggle("Show Return Button", isOn: Binding(get: { !hideReturnControl }, set: { hideReturnControl = !$0 }))

--- a/scripts/patch_guest_return.py
+++ b/scripts/patch_guest_return.py
@@ -40,6 +40,14 @@ CONTROL = GEOMETRY + r'''
     [self.button setImage:[UIImage systemImageNamed:@"arrow.uturn.backward.circle.fill"] forState:UIControlStateNormal];
     self.button.accessibilityLabel = @"Return to LiveContainer";
     self.button.accessibilityHint = @"Minimizes this guest without closing it";
+    __weak typeof(self) weakControl = self;
+    self.button.menu = [UIMenu menuWithTitle:@"" children:@[
+        [UIAction actionWithTitle:@"Hide Return Button" image:[UIImage systemImageNamed:@"eye.slash"] identifier:nil handler:^(__kindof UIAction *action) {
+            [NSUserDefaults.lcUserDefaults setBool:YES forKey:@"LCHideReturnControl"];
+            [weakControl setNeedsLayout];
+            NSLog(@"[LC_RETURN] CONTROL_HIDDEN");
+        }]
+    ]];
     [self.button addTarget:self action:@selector(tapped) forControlEvents:UIControlEventTouchUpInside];
     [self.button addGestureRecognizer:[[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(drag:)]];
     [self addSubview:self.button];
@@ -72,7 +80,7 @@ CONTROL = GEOMETRY + r'''
     [super layoutSubviews];
     CGRect rect = [self availableRect];
     // A 44-point target must not be placed outside a tiny resized window.
-    self.button.hidden = CGRectIsNull(rect) || rect.size.width < 44 || rect.size.height < 44;
+    self.button.hidden = [NSUserDefaults.lcUserDefaults boolForKey:@"LCHideReturnControl"] || CGRectIsNull(rect) || rect.size.width < 44 || rect.size.height < 44;
     if (self.button.hidden) return;
     self.button.bounds = CGRectMake(0, 0, 44, 44);
     self.button.center = CGPointMake(LCReturnAxisCenter(rect.origin.x, rect.size.width, self.position.x),
@@ -359,6 +367,7 @@ PATHS = (
     "SideStoreSupport/SideStoreHooks.m", "LiveContainerSwiftUI/Models/LCAppModel.swift",
     "LiveContainerSwiftUI/Views/LCTabView.swift",
     "LiveContainer/LCBootstrap.m",
+    "LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift",
 )
 
 
@@ -377,7 +386,7 @@ def section(text, start, end, replacement, label):
 
 
 def verify(texts):
-    implementation, header, window, dock, hooks, model, tab, bootstrap = (texts[p] for p in PATHS)
+    implementation, header, window, dock, hooks, model, tab, bootstrap, settings = (texts[p] for p in PATHS)
     for text, token in ((implementation, CONTROL), (implementation, METHODS), (implementation, CLEANUP),
                         (window, WINDOW_MANAGER), (dock, DOCK_RESUME), (header, "lcActivateHost"),
                         (hooks, "DIRECT_PROCESS_RESTART_RETURN"), (model, "LC_RETURN_CONTAINER_GUARD"),
@@ -388,12 +397,14 @@ def verify(texts):
         raise ValueError("Global cross-window callback survived")
     if DIRECT_CONTROL.strip() not in bootstrap or DIRECT_RUNTIME.strip() not in bootstrap:
         raise ValueError("Incomplete direct guest Return patch")
+    if 'Toggle("Show Return Button"' not in settings:
+        raise ValueError("Return visibility setting missing")
 
 
 def patch(root):
     root = Path(root)
     texts = {p: (root / p).read_text(encoding="utf-8") for p in PATHS}
-    implementation, header, window, dock, hooks, model, tab, bootstrap = (texts[p] for p in PATHS)
+    implementation, header, window, dock, hooks, model, tab, bootstrap, settings = (texts[p] for p in PATHS)
     if MARKER in implementation:
         verify(texts)
         return
@@ -467,7 +478,12 @@ def patch(root):
     tab = replace(tab, "                    DataManager.shared.model.mainWindowOpened = false", "                    DataManager.shared.model.mainWindowOpened = false\n                    if #available(iOS 16.1, *), MultitaskWindowManager.mainSceneSession?.persistentIdentifier == scene1.session.persistentIdentifier {\n                        MultitaskWindowManager.mainSceneSession = nil\n                    }", "clear disconnected main scene")
     bootstrap = replace(bootstrap, "extern char **environ;", "#include <math.h>\n" + DIRECT_CONTROL + DIRECT_RUNTIME + "\nextern char **environ;", "direct return presenter")
     bootstrap = replace(bootstrap, "    // Go!", "    // Install before guest UIApplication/scene creation, never inside LiveProcess.\n    if (!isLiveProcess && !isSideStore) {\n        lcDirectReturnPresenter = [LCDirectReturnPresenter new];\n    }\n    // Go!", "direct launch route")
-    updated = dict(zip(PATHS, (implementation, header, window, dock, hooks, model, tab, bootstrap)))
+    settings = replace(settings, "    @State var errorShow = false", '    @AppStorage("LCHideReturnControl", store: UserDefaults.lcUserDefaults) private var hideReturnControl = false\n    @State var errorShow = false', "visibility preference")
+    settings = replace(settings, "            Form {", '''            Form {
+                Section("Guest Controls") {
+                    Toggle("Show Return Button", isOn: Binding(get: { !hideReturnControl }, set: { hideReturnControl = !$0 }))
+                }''', "restore return control")
+    updated = dict(zip(PATHS, (implementation, header, window, dock, hooks, model, tab, bootstrap, settings)))
     verify(updated)
     # Validate every anchor before writing any file, so upstream drift is not a partial patch.
     for relative, text in updated.items():

--- a/scripts/patch_guest_return.py
+++ b/scripts/patch_guest_return.py
@@ -283,11 +283,82 @@ CLEANUP = r'''
 }
 '''
 
+DIRECT_CONTROL = CONTROL.replace("LCReturnControl", "LCDirectReturnControl").replace(
+    'Minimizes this guest without closing it', 'Restarts LiveContainer and closes this guest'
+)
+
+DIRECT_RUNTIME = r'''
+// LC_DIRECT_RETURN_V1: direct guests share the host process, not the dock registry.
+@interface LCDirectReturnWindow : UIWindow
+@end
+@implementation LCDirectReturnWindow
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    UIView *hit = [super hitTest:point withEvent:event];
+    return (hit == self || hit == self.rootViewController.view) ? nil : hit;
+}
+@end
+
+@interface LCDirectReturnPresenter : NSObject
+@property(nonatomic, strong) NSMutableDictionary<NSString *, LCDirectReturnWindow *> *windows;
+@end
+@implementation LCDirectReturnPresenter
+- (instancetype)init {
+    if (!(self = [super init])) return nil;
+    self.windows = [NSMutableDictionary new];
+    NSNotificationCenter *center = NSNotificationCenter.defaultCenter;
+    [center addObserver:self selector:@selector(show:) name:UIWindowDidBecomeVisibleNotification object:nil];
+    [center addObserver:self selector:@selector(show:) name:UISceneDidActivateNotification object:nil];
+    [center addObserver:self selector:@selector(disconnect:) name:UISceneDidDisconnectNotification object:nil];
+    return self;
+}
+- (void)show:(NSNotification *)notification {
+    if (!NSThread.isMainThread) {
+        dispatch_async(dispatch_get_main_queue(), ^{ [self show:notification]; });
+        return;
+    }
+    UIWindowScene *scene = nil;
+    if ([notification.object isKindOfClass:UIWindow.class]) {
+        UIWindow *source = notification.object;
+        if ([source isKindOfClass:LCDirectReturnWindow.class] || source.windowLevel != UIWindowLevelNormal) return;
+        scene = source.windowScene;
+    } else if ([notification.object isKindOfClass:UIWindowScene.class]) {
+        scene = notification.object;
+    }
+    if (!scene || ![scene.session.role isEqualToString:UIWindowSceneSessionRoleApplication]) return;
+    NSString *identity = scene.session.persistentIdentifier;
+    if (self.windows[identity]) return;
+    LCDirectReturnWindow *window = [[LCDirectReturnWindow alloc] initWithWindowScene:scene];
+    UIViewController *controller = [UIViewController new];
+    window.rootViewController = controller;
+    window.backgroundColor = UIColor.clearColor;
+    window.windowLevel = UIWindowLevelAlert + 1;
+    LCDirectReturnControl *control = [[LCDirectReturnControl alloc] initWithFrame:window.bounds];
+    controller.view = control;
+    control.action = ^{
+        NSLog(@"[LC_RETURN] RETURN_REQUESTED mode=DIRECT_PROCESS_RESTART_RETURN");
+        // Match the upstream SideStore escape path. Never used by LiveProcess.
+        [LCSharedUtils launchToGuestAppWithClassicMode:0];
+    };
+    self.windows[identity] = window;
+    window.hidden = NO; // Do not steal key-window status from the guest or its keyboard.
+    NSLog(@"[LC_RETURN] MODE_DIRECT mode=DIRECT_PROCESS_RESTART_RETURN pid=%d", getpid());
+}
+- (void)disconnect:(NSNotification *)notification {
+    if ([notification.object isKindOfClass:UIWindowScene.class]) {
+        UIWindowScene *scene = notification.object;
+        [self.windows removeObjectForKey:scene.session.persistentIdentifier];
+    }
+}
+@end
+static LCDirectReturnPresenter *lcDirectReturnPresenter;
+'''
+
 PATHS = (
     "MultitaskSupport/AppSceneViewController.m", "MultitaskSupport/AppSceneViewController.h",
     "MultitaskSupport/MultitaskAppWindow.swift", "MultitaskSupport/MultitaskDockView.swift",
     "SideStoreSupport/SideStoreHooks.m", "LiveContainerSwiftUI/Models/LCAppModel.swift",
     "LiveContainerSwiftUI/Views/LCTabView.swift",
+    "LiveContainer/LCBootstrap.m",
 )
 
 
@@ -306,7 +377,7 @@ def section(text, start, end, replacement, label):
 
 
 def verify(texts):
-    implementation, header, window, dock, hooks, model, tab = (texts[p] for p in PATHS)
+    implementation, header, window, dock, hooks, model, tab, bootstrap = (texts[p] for p in PATHS)
     for text, token in ((implementation, CONTROL), (implementation, METHODS), (implementation, CLEANUP),
                         (window, WINDOW_MANAGER), (dock, DOCK_RESUME), (header, "lcActivateHost"),
                         (hooks, "DIRECT_PROCESS_RESTART_RETURN"), (model, "LC_RETURN_CONTAINER_GUARD"),
@@ -315,12 +386,14 @@ def verify(texts):
             raise ValueError("Incomplete guest-return patch: " + token[:65])
     if "DataManager.shared.model.pidCallback" in window:
         raise ValueError("Global cross-window callback survived")
+    if DIRECT_CONTROL.strip() not in bootstrap or DIRECT_RUNTIME.strip() not in bootstrap:
+        raise ValueError("Incomplete direct guest Return patch")
 
 
 def patch(root):
     root = Path(root)
     texts = {p: (root / p).read_text(encoding="utf-8") for p in PATHS}
-    implementation, header, window, dock, hooks, model, tab = (texts[p] for p in PATHS)
+    implementation, header, window, dock, hooks, model, tab, bootstrap = (texts[p] for p in PATHS)
     if MARKER in implementation:
         verify(texts)
         return
@@ -392,7 +465,9 @@ def patch(root):
     hooks = replace(hooks, "    [LCSharedUtils launchToGuestAppWithClassicMode:0];", '    NSLog(@"[LC_RETURN] MODE_DIRECT mode=DIRECT_PROCESS_RESTART_RETURN");\n    [LCSharedUtils launchToGuestAppWithClassicMode:0];', "direct fallback diagnostic")
     tab = replace(tab, "            shouldToggleMainWindowOpen = true\n", "            shouldToggleMainWindowOpen = true\n            if #available(iOS 16.1, *) {\n                MultitaskWindowManager.mainSceneSession = sceneDelegate.window?.windowScene?.session\n            }\n", "capture real main scene")
     tab = replace(tab, "                    DataManager.shared.model.mainWindowOpened = false", "                    DataManager.shared.model.mainWindowOpened = false\n                    if #available(iOS 16.1, *), MultitaskWindowManager.mainSceneSession?.persistentIdentifier == scene1.session.persistentIdentifier {\n                        MultitaskWindowManager.mainSceneSession = nil\n                    }", "clear disconnected main scene")
-    updated = dict(zip(PATHS, (implementation, header, window, dock, hooks, model, tab)))
+    bootstrap = replace(bootstrap, "extern char **environ;", "#include <math.h>\n" + DIRECT_CONTROL + DIRECT_RUNTIME + "\nextern char **environ;", "direct return presenter")
+    bootstrap = replace(bootstrap, "    // Go!", "    // Install before guest UIApplication/scene creation, never inside LiveProcess.\n    if (!isLiveProcess && !isSideStore) {\n        lcDirectReturnPresenter = [LCDirectReturnPresenter new];\n    }\n    // Go!", "direct launch route")
+    updated = dict(zip(PATHS, (implementation, header, window, dock, hooks, model, tab, bootstrap)))
     verify(updated)
     # Validate every anchor before writing any file, so upstream drift is not a partial patch.
     for relative, text in updated.items():

--- a/scripts/patch_guest_return.py
+++ b/scripts/patch_guest_return.py
@@ -132,15 +132,27 @@ CONTROL = GEOMETRY + r'''
 METHODS = r'''
 - (void)viewDidLayoutSubviews {
     [super viewDidLayoutSubviews];
+    if (self.isAppTerminationCleanUpCalled) {
+        [self.lcReturnControl removeFromSuperview];
+        return;
+    }
     if (!self.lcReturnControl) {
         self.lcReturnControl = [[LCReturnControl alloc] initWithFrame:self.view.bounds];
         __weak typeof(self) weakSelf = self;
         self.lcReturnControl.action = ^{ [weakSelf lcReturnToHost]; };
-        [self.view addSubview:self.lcReturnControl];
     }
-    self.lcReturnControl.frame = self.view.bounds;
+    // Virtual-window chrome overlays the guest controller. Keep the control
+    // above those input views, not inside the remotely hosted content layer.
+    UIView *overlayHost = [self.delegate isKindOfClass:DecoratedAppSceneViewController.class]
+        ? [(DecoratedAppSceneViewController *)self.delegate view] : self.view;
+    if (self.lcReturnControl.superview != overlayHost) {
+        [self.lcReturnControl removeFromSuperview];
+        [overlayHost addSubview:self.lcReturnControl];
+        NSLog(@"[LC_RETURN] CONTROL_ATTACHED layer=%@", overlayHost == self.view ? @"native" : @"virtual_window_chrome");
+    }
+    self.lcReturnControl.frame = [self.view convertRect:self.view.bounds toView:overlayHost];
     self.lcReturnControl.hidden = !self.isAppRunning;
-    [self.view bringSubviewToFront:self.lcReturnControl];
+    [overlayHost bringSubviewToFront:self.lcReturnControl];
 }
 - (void)lcReturnToHost {
     NSLog(@"[LC_RETURN] RETURN_REQUESTED pid=%d", self.pid);
@@ -288,6 +300,7 @@ CLEANUP = r'''
     if (_isAppTerminationCleanUpCalled) return;
     _isAppTerminationCleanUpCalled = true;
     self.lcReturnControl.hidden = YES;
+    [self.lcReturnControl removeFromSuperview];
     if (self.sceneID) {
         [[PrivClass(FBSceneManager) sharedInstance] destroyScene:self.sceneID withTransitionContext:nil];
     }

--- a/scripts/patch_livecontainer_autorefresh.py
+++ b/scripts/patch_livecontainer_autorefresh.py
@@ -226,6 +226,9 @@ def verify(root: Path) -> None:
         for relative in ("LiveContainerSwiftUI/App/AppDelegate.swift", "LiveContainerSwiftUI/App/LiveContainerAutoRefreshAlarm.swift",
                          "LiveContainerSwiftUI/Views/Settings/LCEmbeddedSideStoreRefreshView.swift", "SideStoreSupport/SideStore.swift"):
             subprocess.run([compiler, "-frontend", "-parse", str(root / relative)], check=True)
+        client = root / "SideStoreSupport/SideStoreClient.swift"
+        if client.exists():
+            subprocess.run([compiler, "-frontend", "-parse", str(client)], check=True)
 
 
 def main() -> None:
@@ -240,6 +243,8 @@ def main() -> None:
     patch_project(root)
     patch_alarm_provider(root)
     patch_settings(root)
+    from patch_refresh_result_bridge import patch as patch_result_bridge
+    patch_result_bridge(root)
     verify(root)
     print("LiveContainer host auto-refresh patch applied and verified")
 

--- a/scripts/patch_livecontainer_autorefresh.py
+++ b/scripts/patch_livecontainer_autorefresh.py
@@ -22,7 +22,7 @@ def template(name: str) -> str:
     return (TEMPLATES / name).read_text(encoding="utf-8")
 
 
-HOST_SCHEDULER = template("livecontainer_refresh_policy.swift") + "\n" + template("livecontainer_refresh_scheduler.swift")
+HOST_SCHEDULER = template("livecontainer_refresh_policy.swift") + "\n" + template("livecontainer_network_preflight.swift") + "\n" + template("livecontainer_refresh_scheduler.swift")
 ALARM_PROVIDER = template("livecontainer_refresh_alarm.swift")
 SETTINGS_VIEW = template("livecontainer_refresh_settings.swift")
 BRIDGE = r'''

--- a/scripts/patch_refresh_result_bridge.py
+++ b/scripts/patch_refresh_result_bridge.py
@@ -1,0 +1,105 @@
+"""Carry refresh metadata across the existing XPC boundary, not guest preferences."""
+from pathlib import Path
+
+MARKER = "LC_REFRESH_RESULT_XPC_V1"
+
+
+def replace(text, old, new):
+    if text.count(old) != 1:
+        raise SystemExit(f"refresh result bridge: expected one anchor {old[:80]!r}")
+    return text.replace(old, new, 1)
+
+
+HOST = r'''
+    // LC_REFRESH_RESULT_XPC_V1: accept only this outstanding host request.
+    func finishRefresh(_ error: String?, runID: String, verification: Data?) {
+        guard let defaults = UserDefaults(suiteName: "group.com.SideStore.SideStore") else {
+            finish("LiveContainer could not open its refresh-state store. Refresh is unconfirmed.")
+            return
+        }
+        guard c != nil, defaults.string(forKey: "liveContainerAutoRefreshExpectedRunID") == runID else {
+            NSLog("[LIVE_CONTAINER_REFRESH] RESULT_REJECTED reason=stale_run")
+            return
+        }
+        if let verification, verification.count <= 262144 {
+            do {
+                let object = try PropertyListSerialization.propertyList(from: verification, options: [], format: nil)
+                guard let payload = object as? [String: Any],
+                      let manifest = payload["liveContainerAutoRefreshVerification"] as? [String: Any],
+                      manifest["run_id"] as? String == runID else {
+                    finish(error ?? "SideStore returned results for a different refresh attempt. Open SideStore and check its refresh history.")
+                    return
+                }
+                defaults.set(manifest, forKey: "liveContainerAutoRefreshVerification")
+                if payload["liveContainerAutoRefreshHostHandoffRunID"] as? String == runID {
+                    for key in ["liveContainerAutoRefreshHostHandoff", "liveContainerAutoRefreshHostHandoffRunID", "liveContainerAutoRefreshHostHandoffStartedAt", "liveContainerAutoRefreshHostPreviousExpiration"] {
+                        if let value = payload[key] { defaults.set(value, forKey: key) }
+                    }
+                }
+                NSLog("[LIVE_CONTAINER_REFRESH] RESULT_RECEIVED run_id=%@", runID)
+            } catch {
+                finish("SideStore's installation results could not be read. Check its refresh history before retrying.")
+                return
+            }
+        } else if error == nil {
+            finish("SideStore returned no readable installation results. Refresh is unconfirmed; check embedded SideStore history.")
+            return
+        }
+        finish(error)
+    }
+'''
+
+CLIENT = r'''
+    // LC_REFRESH_RESULT_XPC_V1: bounded, allowlisted non-secret metadata only.
+    func reportRefreshResult(_ error: String?, server: any RefreshServer) {
+        guard let defaults = UserDefaults(suiteName: "group.com.SideStore.SideStore") else {
+            server.finish("SideStore could not open its refresh-state store. Refresh is unconfirmed.")
+            return
+        }
+        guard let runID = defaults.string(forKey: "liveContainerAutoRefreshExpectedRunID") else {
+            server.finish(error)
+            return
+        }
+        var payload: [String: Any] = [:]
+        for key in ["liveContainerAutoRefreshVerification", "liveContainerAutoRefreshHostHandoff", "liveContainerAutoRefreshHostHandoffRunID", "liveContainerAutoRefreshHostHandoffStartedAt", "liveContainerAutoRefreshHostPreviousExpiration"] {
+            if let value = defaults.object(forKey: key) { payload[key] = value }
+        }
+        do {
+            let data = try PropertyListSerialization.data(fromPropertyList: payload, format: .binary, options: 0)
+            guard data.count <= 262144 else {
+                server.finishRefresh("SideStore's verification results exceeded the allowed size.", runID: runID, verification: nil)
+                return
+            }
+            server.finishRefresh(error, runID: runID, verification: data)
+        } catch {
+            server.finishRefresh("SideStore could not encode installation results: " + error.localizedDescription, runID: runID, verification: nil)
+        }
+    }
+'''
+
+
+def patch(root: Path):
+    paths = [root / "SideStoreSupport" / name for name in
+             ("XPCServer.h", "XPCClient.m", "SideStore.swift", "SideStoreClient.swift")]
+    header, objc, host, client = [p.read_text(encoding="utf-8") for p in paths]
+    if MARKER in header:
+        assert HOST in host and CLIENT in client and "refreshRunID" in objc
+        return
+    header = replace(header, "- (void)finish:(NSString*)error;", "- (void)finish:(NSString*)error;\n// LC_REFRESH_RESULT_XPC_V1\n- (void)finishRefresh:(NSString* _Nullable)error runID:(NSString* _Nonnull)runID verification:(NSData* _Nullable)verification NS_SWIFT_NAME(finishRefresh(_:runID:verification:));")
+    signature = "mangledTypeName:(NSString *)mangledTypeName"
+    header = replace(header, signature + ";", signature + " refreshRunID:(NSString* _Nullable)refreshRunID;")
+    objc = replace(objc, signature + " {", signature + " refreshRunID:(NSString* _Nullable)refreshRunID {")
+    objc = replace(objc, "    [self performRefreshForRealWithIdentifier:", '''    NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.com.SideStore.SideStore"];
+    [defaults removeObjectForKey:@"liveContainerAutoRefreshVerification"];
+    [defaults removeObjectForKey:@"liveContainerAutoRefreshHostHandoff"];
+    [defaults removeObjectForKey:@"liveContainerAutoRefreshHostHandoffRunID"];
+    if (refreshRunID.length) [defaults setObject:refreshRunID forKey:@"liveContainerAutoRefreshExpectedRunID"];
+    else [defaults removeObjectForKey:@"liveContainerAutoRefreshExpectedRunID"];
+    [self performRefreshForRealWithIdentifier:''')
+    host = replace(host, "client.refreshAllApps(withIdentifier: identifier, mangledTypeName: mangledName)", 'client.refreshAllApps(withIdentifier: identifier, mangledTypeName: mangledName, refreshRunID: UserDefaults(suiteName: "group.com.SideStore.SideStore")?.string(forKey: "liveContainerAutoRefreshExpectedRunID"))')
+    host = replace(host, "    func finish(_ error: String?) {", HOST + "\n    func finish(_ error: String?) {")
+    client = replace(client, "    @objc(performRefreshForRealWithIdentifier:mangledTypeName:server:)", CLIENT + "\n    @objc(performRefreshForRealWithIdentifier:mangledTypeName:server:)")
+    client = replace(client, "                server.finish(nil)", "                reportRefreshResult(nil, server: server)")
+    client = replace(client, "                server.finish(error.localizedDescription)", "                reportRefreshResult(error.localizedDescription, server: server)")
+    for path, text in zip(paths, (header, objc, host, client)):
+        path.write_text(text, encoding="utf-8")

--- a/scripts/templates/embedded_shared_keychain.swift
+++ b/scripts/templates/embedded_shared_keychain.swift
@@ -1,0 +1,229 @@
+// LC_EMBEDDED_SHARED_KEYCHAIN_V1. Only injected into the combined product.
+// Keep credentials in Keychain, never in UserDefaults, app-group files, or XPC.
+// Host and LiveProcess already share an App Group, but not necessarily their
+// DEFAULT keychain access group. Explicitly select the installed App Group.
+
+// LC_SHARED_MIGRATION_POLICY_BEGIN
+struct LCLegacyKeychainItem {
+    let group: String
+    let key: String
+    let data: Data
+}
+
+enum LCSharedKeychainMigration {
+    static let marker = "LCSharedKeychainReadyV1"
+    static let ready = Data("1".utf8)
+    static let authKeys = ["appleIDEmailAddress", "appleIDPassword", "appleIDAdsid", "appleIDXcodeToken"]
+    static let knownKeys = Set(authKeys + ["signingCertificate", "signingCertificatePassword",
+        "signingCertificatePrivateKey", "signingCertificateSerialNumber", "identifier", "adiPb"])
+
+    static func supported(_ key: String) -> Bool {
+        knownKeys.contains(key) || (key.hasPrefix("importedCert_") && key.count <= 256)
+    }
+
+    static func complete(_ values: [String: Data]) -> Bool {
+        func present(_ key: String) -> Bool {
+            guard let data = values[key], let value = String(data: data, encoding: .utf8) else { return false }
+            return !value.isEmpty
+        }
+        return (present("appleIDEmailAddress") && present("appleIDPassword")) ||
+            (present("appleIDAdsid") && present("appleIDXcodeToken"))
+    }
+
+    /// Returns true only after a verified migration, or an existing committed
+    /// namespace. No mixing credentials from different legacy access groups.
+    static func prepare(group: String, items: () throws -> [LCLegacyKeychainItem],
+                        read: (String) throws -> Data?, write: (String, Data) throws -> Void) throws -> Bool {
+        if try read(marker) == ready { return true }
+        var candidates: [String: [String: Data]] = [:]
+        for item in try items() where item.group != group && supported(item.key) {
+            if let previous = candidates[item.group]?[item.key], previous != item.data {
+                throw NSError(domain: "LiveContainerRefresh.Configuration", code: 1008)
+            }
+            candidates[item.group, default: [:]][item.key] = item.data
+        }
+        let completeSets = candidates.values.filter { complete($0) }
+        guard let source = completeSets.first else { return false }
+        guard completeSets.allSatisfy({ $0 == source }) else {
+            throw NSError(domain: "LiveContainerRefresh.Configuration", code: 1008)
+        }
+        // Check ALL conflicts before writing anything. Partial migrations can
+        // retry, but may not overwrite credentials from a different sign-in.
+        for key in source.keys.sorted() {
+            if let existing = try read(key), existing != source[key] {
+                throw NSError(domain: "LiveContainerRefresh.Configuration", code: 1008)
+            }
+        }
+        for key in source.keys.sorted() {
+            let value = source[key]!
+            if try read(key) == nil { try write(key, value) }
+            guard try read(key) == value else {
+                throw NSError(domain: "com.SideStore.Keychain", code: 1009)
+            }
+        }
+        // Readers ignore an incomplete migration until this commit marker.
+        try write(marker, ready)
+        guard try read(marker) == ready else {
+            throw NSError(domain: "com.SideStore.Keychain", code: 1009)
+        }
+        return true
+    }
+}
+// LC_SHARED_MIGRATION_POLICY_END
+
+fileprivate enum LCEmbeddedSharedKeychain {
+    private static let lock = NSLock()
+    private static var lastIssues: [String: Int] = [:]
+    private static var installedGroup: String?
+    private static var service = ""
+
+    static func makeClient() -> KeychainAccess.Keychain {
+        installedGroup = nil
+        service = Bundle.Info.appbundleIdentifier
+        let group = Bundle.main.altstoreAppGroup
+        // The normal identity hooks must already have run. Do not quietly
+        // persist new credentials into an unshared, process-private namespace.
+        if service == "com.kdt.livecontainer", let group, !group.isEmpty {
+            installedGroup = group
+            debugLog("[LC_KEYCHAIN] SHARED_GROUP_SELECTED service=\(service) group=\(group)")
+            return KeychainAccess.Keychain(service: service, accessGroup: group)
+                .accessibility(.afterFirstUnlock).synchronizable(true)
+        }
+        note("configuration", status: -34018)
+        // A client is required by existing upstream certificate APIs; auth
+        // reads/writes below fail closed until configuration is available.
+        return KeychainAccess.Keychain(service: service)
+            .accessibility(.afterFirstUnlock).synchronizable(true)
+    }
+
+    static func prepare(_ client: KeychainAccess.Keychain) {
+        guard let group = installedGroup else { return }
+        do {
+            let ready = try LCSharedKeychainMigration.prepare(group: group,
+                items: { try legacyItems(service: service) },
+                read: { try client.getData($0) }, write: { try client.set($1, key: $0) })
+            note("migration", status: ready ? 0 : -25300)
+            debugLog("[LC_KEYCHAIN] MIGRATION_READY value=\(ready) pid=\(ProcessInfo.processInfo.processIdentifier)")
+        } catch { note("migration", status: (error as NSError).code) }
+    }
+
+    private static func legacyItems(service: String) throws -> [LCLegacyKeychainItem] {
+        // Exact SideStore service only; securityd limits results to groups this
+        // process is already entitled to. Never scan other apps' services.
+        let query: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service, kSecAttrSynchronizable as String: kSecAttrSynchronizableAny,
+            kSecMatchLimit as String: kSecMatchLimitAll, kSecReturnAttributes as String: true,
+            kSecReturnData as String: true, kSecUseAuthenticationUI as String: kSecUseAuthenticationUIFail]
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { return [] }
+        guard status == errSecSuccess else { throw NSError(domain: NSOSStatusErrorDomain, code: Int(status)) }
+        guard let rows = result as? [[String: Any]] else {
+            throw NSError(domain: "com.SideStore.Keychain", code: 1009)
+        }
+        return rows.compactMap { row in
+            guard let group = row[kSecAttrAccessGroup as String] as? String,
+                  let key = row[kSecAttrAccount as String] as? String,
+                  let data = row[kSecValueData as String] as? Data else { return nil }
+            return LCLegacyKeychainItem(group: group, key: key, data: data)
+        }
+    }
+
+    static func isReady(_ client: KeychainAccess.Keychain) -> Bool {
+        guard installedGroup != nil else { return false }
+        do { return try client.getData(LCSharedKeychainMigration.marker) == LCSharedKeychainMigration.ready }
+        catch { note("migration", status: (error as NSError).code); return false }
+    }
+
+    static func readString(_ key: String, client: KeychainAccess.Keychain) -> String? {
+        guard let data = read(key, client: client) else { return nil }
+        guard let value = String(data: data, encoding: .utf8) else {
+            note(key, status: 1009); return nil
+        }
+        return value
+    }
+
+    static func read(_ key: String, client: KeychainAccess.Keychain) -> Data? {
+        guard installedGroup != nil else { note(key, status: -34018); return nil }
+        do {
+            let ready = try client.getData(LCSharedKeychainMigration.marker) == LCSharedKeychainMigration.ready
+            if !ready && LCSharedKeychainMigration.authKeys.contains(key) {
+                note(key, status: -25300); return nil
+            }
+            var data = try client.getData(key)
+            if data == nil && !ready && !LCSharedKeychainMigration.authKeys.contains(key) {
+                // Preserve certificate-only/imported-certificate setups before
+                // an Apple login is migrated. This fallback is READ ONLY and
+                // cannot make an authentication preflight pass.
+                let legacy = KeychainAccess.Keychain(service: service)
+                    .accessibility(.afterFirstUnlock).synchronizable(true)
+                data = try legacy.getData(key)
+            }
+            if ready { note("migration", status: 0) }
+            note(key, status: data == nil ? -25300 : 0)
+            return data
+        } catch { note(key, status: (error as NSError).code); return nil }
+    }
+
+    static func write(_ key: String, data: Data?, client: KeychainAccess.Keychain) {
+        guard installedGroup != nil else { note(key, status: -34018); return }
+        do {
+            // Also retained on sign-out: never resurrect an old login on restart.
+            if LCSharedKeychainMigration.authKeys.contains(key),
+               try client.getData(LCSharedKeychainMigration.marker) != LCSharedKeychainMigration.ready {
+                try client.set(LCSharedKeychainMigration.ready, key: LCSharedKeychainMigration.marker)
+            }
+            if let data { try client.set(data, key: key) } else { try client.remove(key) }
+            guard try client.getData(key) == data else {
+                throw NSError(domain: "com.SideStore.Keychain", code: 1009)
+            }
+            note(key, status: 0)
+        } catch { note(key, status: (error as NSError).code) }
+    }
+
+    static func clearAll(_ client: KeychainAccess.Keychain) {
+        guard installedGroup != nil else { note("configuration", status: -34018); return }
+        do {
+            // Keep the migration tombstone. Remove only this service's items,
+            // not the whole group and not other apps' credentials.
+            for key in client.allKeys() where key != LCSharedKeychainMigration.marker {
+                try client.remove(key)
+            }
+            try client.set(LCSharedKeychainMigration.ready, key: LCSharedKeychainMigration.marker)
+            note("clear", status: 0)
+        } catch { note("clear", status: (error as NSError).code) }
+    }
+
+    private static func note(_ key: String, status: Int) {
+        // Item names and status ONLY. Never log values or NSError.userInfo,
+        // which third-party wrappers may populate with a complete query.
+        lock.lock()
+        if status == 0 { lastIssues.removeValue(forKey: key) } else { lastIssues[key] = status }
+        lock.unlock()
+        let label = LCSharedKeychainMigration.knownKeys.contains(key) ? key : "storage"
+        debugLog("[LC_KEYCHAIN] ACCESS item=\(label) status=\(status) pid=\(ProcessInfo.processInfo.processIdentifier)")
+    }
+
+    static func authenticationFailure() -> NSError {
+        lock.lock(); let issues = lastIssues; lock.unlock()
+        let statuses = Set(issues.values)
+        if statuses.contains(-34018) {
+            return NSError(domain: "LiveContainerRefresh.Configuration", code: 1006,
+                userInfo: [NSLocalizedDescriptionKey: "This installation cannot access SideStore's shared Keychain group. Keep the LiveProcess extension and use the same signing team; do not sign out. Check LC_KEYCHAIN diagnostics."])
+        }
+        if statuses.contains(-25308) || statuses.contains(-25291) || statuses.contains(-25315) {
+            return NSError(domain: "com.SideStore.Keychain", code: 1005,
+                userInfo: [NSLocalizedDescriptionKey: "Saved sign-in details are temporarily inaccessible. Unlock the iPhone and retry; your account has not been signed out."])
+        }
+        if statuses.contains(1008) {
+            return NSError(domain: "LiveContainerRefresh.Configuration", code: 1008,
+                userInfo: [NSLocalizedDescriptionKey: "Conflicting saved SideStore logins were found. Automatic migration stopped without replacing them. Open embedded SideStore to choose the intended account."])
+        }
+        if let status = statuses.sorted().first(where: { $0 != -25300 }) {
+            return NSError(domain: "com.SideStore.Keychain", code: 1009,
+                userInfo: [NSLocalizedDescriptionKey: "SideStore Keychain access failed (status \(status)). Your account has not been signed out. Check LC_KEYCHAIN diagnostics."])
+        }
+        return NSError(domain: "com.SideStore.Authentication", code: 1004,
+            userInfo: [NSLocalizedDescriptionKey: "Open embedded SideStore once in this LiveContainer installation so its existing sign-in can be migrated to the shared Keychain, then return and retry. If SideStore itself asks you to sign in, complete that there."])
+    }
+}

--- a/scripts/templates/livecontainer_network_preflight.swift
+++ b/scripts/templates/livecontainer_network_preflight.swift
@@ -1,0 +1,126 @@
+import Network
+import Darwin
+
+// One-shot checks owned by an actual refresh run. No idle monitoring.
+@MainActor
+enum LiveContainerNetworkPreflight {
+    private static let pendingKey = "liveContainerPendingVPNRefresh"
+    private static var defaults: UserDefaults { LiveContainerAutoRefreshScheduler.defaults }
+
+    // Consume once on a fresh host launch; never replay an expired handoff.
+    static func consumePendingReturn() -> Bool {
+        guard let date = defaults.object(forKey: pendingKey) as? Date else { return false }
+        defaults.removeObject(forKey: pendingKey)
+        let age = Date().timeIntervalSince(date)
+        guard age >= 0 && age < 120 else {
+            print("[AUTO_REFRESH] LOCALDEVVPN_VERIFY_FAIL reason=expired_handoff")
+            return false
+        }
+        return true
+    }
+    private static func failure(_ code: Int, _ message: String) -> NSError {
+        NSError(domain: "LiveContainerRefresh.Network", code: code,
+                userInfo: [NSLocalizedDescriptionKey: message])
+    }
+
+    static func wifiAvailable() async -> Bool {
+        let monitor = NWPathMonitor(requiredInterfaceType: .wifi)
+        return await withCheckedContinuation { continuation in
+            var completed = false
+            func finish(_ available: Bool) {
+                guard !completed else { return }
+                completed = true
+                monitor.cancel()
+                continuation.resume(returning: available)
+            }
+            monitor.pathUpdateHandler = { path in
+                let available = path.status == .satisfied && path.usesInterfaceType(.wifi)
+                Task { @MainActor in finish(available) }
+            }
+            monitor.start(queue: DispatchQueue(label: "LiveContainer.WiFiPreflight"))
+            // Bound a single pending OS path request; this is not a retry loop.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                finish(false)
+            }
+        }
+    }
+
+    static func hasTunnelInterface() -> Bool {
+        var first: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&first) == 0 else { return false }
+        defer { freeifaddrs(first) }
+        var current = first
+        while let entry = current {
+            if String(cString: entry.pointee.ifa_name).hasPrefix("utun"),
+               entry.pointee.ifa_flags & UInt32(IFF_UP) != 0 { return true }
+            current = entry.pointee.ifa_next
+        }
+        return false
+    }
+
+    private static func enableInForeground() async -> Bool {
+        guard UIApplication.shared.applicationState == .active,
+              let scheme = UserDefaults.lcAppUrlScheme(), !scheme.isEmpty else { return false }
+        var components = URLComponents(string: "localdevvpn://enable")!
+        components.queryItems = [URLQueryItem(name: "scheme", value: scheme)]
+        guard let url = components.url else { return false }
+        defaults.set(Date(), forKey: pendingKey)
+        defer { defaults.removeObject(forKey: pendingKey) }
+        return await withCheckedContinuation { continuation in
+            var completed = false
+            var leftHost = false
+            var observers: [NSObjectProtocol] = []
+            func finish(_ returned: Bool) {
+                guard !completed else { return }
+                completed = true
+                observers.forEach { NotificationCenter.default.removeObserver($0) }
+                observers.removeAll()
+                continuation.resume(returning: returned)
+            }
+            observers.append(NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: .main) { _ in
+                Task { @MainActor in leftHost = true }
+            })
+            observers.append(NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: .main) { _ in
+                Task { @MainActor in
+                    guard leftHost else { return }
+                    // A user can also return manually. Neither event proves VPN readiness.
+                    print("[AUTO_REFRESH] LOCALDEVVPN_RETURN_RECEIVED")
+                    finish(true)
+                }
+            })
+            print("[AUTO_REFRESH] LOCALDEVVPN_ENABLE_REQUESTED")
+            UIApplication.shared.open(url, options: [:]) { opened in
+                Task { @MainActor in if !opened { finish(false) } }
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 30) {
+                finish(false)
+            }
+        }
+    }
+
+    static func check(allowForegroundActivation: Bool) async throws {
+        guard await wifiAvailable() else {
+            print("[AUTO_REFRESH] WIFI_PREFLIGHT_FAIL reason=no_wifi_path")
+            throw failure(1, "Wi-Fi is unavailable. Connect to Wi-Fi before refreshing.")
+        }
+        try Task.checkCancellation()
+        print("[AUTO_REFRESH] WIFI_PREFLIGHT_PASS")
+        if !hasTunnelInterface(), allowForegroundActivation {
+            guard await enableInForeground() else {
+                throw failure(2, "LocalDevVPN activation did not return. Enable LocalDevVPN and retry refresh.")
+            }
+            try Task.checkCancellation()
+            guard await wifiAvailable() else {
+                print("[AUTO_REFRESH] WIFI_PREFLIGHT_FAIL reason=wifi_lost_during_activation")
+                throw failure(1, "Wi-Fi was lost while enabling LocalDevVPN. Reconnect and retry.")
+            }
+        }
+        guard hasTunnelInterface() else {
+            if !allowForegroundActivation { print("[AUTO_REFRESH] VPN_UNAVAILABLE_BACKGROUND") }
+            print("[AUTO_REFRESH] LOCALDEVVPN_VERIFY_FAIL reason=no_utun_interface")
+            throw failure(2, "Open LiveContainer and enable LocalDevVPN to continue refresh.")
+        }
+        // Interface presence is not proof of provider identity or CoreDevice readiness.
+        print("[AUTO_REFRESH] VPN_INTERFACE_PRESENT readiness=requires_coredevice_verification")
+    }
+}

--- a/scripts/templates/livecontainer_refresh_scheduler.swift
+++ b/scripts/templates/livecontainer_refresh_scheduler.swift
@@ -459,11 +459,15 @@ enum LiveContainerAutoRefreshScheduler {
         var deadline = defaults.object(forKey: deadlineKey) as? Date
         if deadline == nil || deadline == (defaults.object(forKey: satisfiedDeadlineKey) as? Date) ||
             (defaults.bool(forKey: retryExhaustedKey) && (deadline ?? now) < now) {
+            let advancingExistingWindow = deadline != nil
             deadline = nextDate(after: now)
             defaults.set(deadline, forKey: deadlineKey)
-            defaults.removeObject(forKey: nextRetryKey)
-            defaults.set(false, forKey: retryExhaustedKey)
-            defaults.set(0, forKey: retryCountKey)
+            // Initial schedule creation must not erase a just-recorded failure/backoff.
+            if advancingExistingWindow {
+                defaults.removeObject(forKey: nextRetryKey)
+                defaults.set(false, forKey: retryExhaustedKey)
+                defaults.set(0, forKey: retryCountKey)
+            }
         }
         guard let deadline else { return }
         scheduleDeadlineWarning(deadline) // Pre-scheduled; does not require a future app wake.

--- a/scripts/templates/livecontainer_refresh_scheduler.swift
+++ b/scripts/templates/livecontainer_refresh_scheduler.swift
@@ -162,10 +162,17 @@ enum LiveContainerAutoRefreshScheduler {
 
     private static func verifyRefreshManifest(runID: String) -> (verified: Bool, hostHandoff: Bool, reason: String) {
         let pending = defaults.bool(forKey: hostHandoffKey)
-        guard let manifest = defaults.dictionary(forKey: verificationKey),
-              manifest["run_id"] as? String == runID,
-              let results = manifest["results"] as? [[String: Any]], !results.isEmpty else {
-            return (false, pending, "verification_manifest_missing_or_wrong_run")
+        guard let manifest = defaults.dictionary(forKey: verificationKey) else {
+            print("[LIVE_CONTAINER_REFRESH] VERIFICATION_FAILED reason=manifest_missing run_id=\(runID)")
+            return (false, pending, "SideStore returned without sharing installation results with LiveContainer. Refresh is unconfirmed. Open embedded SideStore and check its refresh history before retrying.")
+        }
+        guard manifest["run_id"] as? String == runID else {
+            print("[LIVE_CONTAINER_REFRESH] VERIFICATION_FAILED reason=run_mismatch expected_run=\(runID) actual_run=\(manifest["run_id"] as? String ?? "missing")")
+            return (false, pending, "LiveContainer received results for a different refresh attempt. This attempt could not be verified. Check embedded SideStore history and retry once the previous refresh finishes.")
+        }
+        guard let results = manifest["results"] as? [[String: Any]], !results.isEmpty else {
+            print("[LIVE_CONTAINER_REFRESH] VERIFICATION_FAILED reason=results_empty run_id=\(runID)")
+            return (false, pending, "SideStore returned no app installation results. No successful refresh was confirmed. Open embedded SideStore to check eligible apps and its refresh history.")
         }
         guard let expected = manifest["expected_ids"] as? [String], !expected.isEmpty,
               Set(results.compactMap { $0["bundle_id"] as? String }) == Set(expected) else {

--- a/scripts/templates/livecontainer_refresh_scheduler.swift
+++ b/scripts/templates/livecontainer_refresh_scheduler.swift
@@ -260,7 +260,7 @@ enum LiveContainerAutoRefreshScheduler {
     private static func execute(source: String, task: BGTask? = nil,
                                 gate: LiveContainerRefreshCompletionGate = LiveContainerRefreshCompletionGate()) async {
         guard !gate.isFinished, !Task.isCancelled else { return }
-        let manual = source == "manual" || source == "alarm_action"
+        let manual = source == "manual" || source == "alarm_action" || source == "vpn_return"
         let now = Date()
         print("[LIVE_CONTAINER_REFRESH] TASK_TRIGGERED source=\(source) at=\(now.timeIntervalSince1970)")
         if source == "bgprocessing" || source == "bgapprefresh" { defaults.set(now, forKey: lastTaskKey) }
@@ -291,6 +291,7 @@ enum LiveContainerAutoRefreshScheduler {
         }
         defer { endRun(runID); schedule() }
         do {
+            try await LiveContainerNetworkPreflight.check(allowForegroundActivation: manual && source != "vpn_return" && task == nil)
             try await performRefresh(runID: runID)
             let verification = verifyRefreshManifest(runID: runID.uuidString)
             if verification.hostHandoff {
@@ -330,7 +331,9 @@ enum LiveContainerAutoRefreshScheduler {
                 defaults.removeObject(forKey: nextRetryKey)
                 defaults.set(true, forKey: retryExhaustedKey)
             }
-            defaults.set("REFRESH_FAILED", forKey: healthStateKey)
+            let networkState = nsError.domain == "LiveContainerRefresh.Network"
+                ? (nsError.code == 1 ? "WIFI_UNAVAILABLE" : "VPN_UNAVAILABLE") : "REFRESH_FAILED"
+            defaults.set(networkState, forKey: healthStateKey)
             defaults.set(error.localizedDescription, forKey: lastErrorKey)
             record(source: source, result: "failure", detail: error.localizedDescription)
             print("[LIVE_CONTAINER_REFRESH] REFRESH_RESULT run_id=\(runID.uuidString) success=false verified=false error_domain=\(nsError.domain) error_code=\(nsError.code) error=\(error.localizedDescription)")
@@ -400,6 +403,10 @@ enum LiveContainerAutoRefreshScheduler {
     static func recoverAfterLaunchOrResume() {
         guard activeRun == nil else { return }
         verifyPendingHostHandoff()
+        if LiveContainerNetworkPreflight.consumePendingReturn() {
+            Task { @MainActor in await execute(source: "vpn_return") }
+            return
+        }
         observeMissedDeadline(now: Date())
         guard defaults.bool(forKey: enabledKey), defaults.object(forKey: earliestEligibleKey) != nil,
               compactWorkIsDue(now: Date()) else { return }

--- a/scripts/templates/livecontainer_refresh_settings.swift
+++ b/scripts/templates/livecontainer_refresh_settings.swift
@@ -73,6 +73,8 @@ struct LCEmbeddedSideStoreRefreshView: View {
     @State private var isSelectingHistory = false
     @State private var selectedHistoryIDs: Set<String> = []
     @State private var showClearHistoryConfirmation = false
+    @AppStorage("liveContainerAutoRefreshLastError", store: UserDefaults(suiteName: "group.com.SideStore.SideStore")) private var lastError = ""
+    @AppStorage("liveContainerAutoRefreshHealthState", store: UserDefaults(suiteName: "group.com.SideStore.SideStore")) private var healthState = "UNKNOWN"
     @AppStorage("liveContainerAutoRefreshEnabled", store: UserDefaults(suiteName: "group.com.SideStore.SideStore")) private var enabled = false
     @AppStorage("liveContainerAutoRefreshFrequency", store: UserDefaults(suiteName: "group.com.SideStore.SideStore")) private var frequency = "interval"
     @AppStorage("liveContainerAutoRefreshWeekday", store: UserDefaults(suiteName: "group.com.SideStore.SideStore")) private var weekday = 2
@@ -96,10 +98,11 @@ struct LCEmbeddedSideStoreRefreshView: View {
                 let protection = strategy == "native_full" ? "Enhanced" :
                     (strategy == "native_without_alarmkit" ? "Standard" : "Limited")
                 Text("Protection: \(protection)")
+                Text("Refresh: \(healthState.replacingOccurrences(of: "_", with: " ").capitalized)")
                 Text("Background execution remains best-effort. A scheduled request is not a completed refresh.")
                     .font(.caption).foregroundColor(.secondary)
-                if let error = defaults.string(forKey: "liveContainerAutoRefreshLastError"), !error.isEmpty {
-                    Text(error).font(.caption).foregroundColor(.red)
+                if !lastError.isEmpty {
+                    Text(lastError).font(.caption).foregroundColor(.red)
                 }
             }
             Section {

--- a/tests/fixtures/livecontainer_scheduler_harness.swift
+++ b/tests/fixtures/livecontainer_scheduler_harness.swift
@@ -5,6 +5,8 @@ extension LiveContainerAutoRefreshScheduler {
         LiveContainerRefreshBridge.calls = 0
         LiveContainerRefreshBridge.fails = false
         LiveContainerRefreshBridge.incomplete = false
+        LiveContainerNetworkPreflight.error = nil
+        LiveContainerNetworkPreflight.checks = 0
         BGTaskScheduler.shared.requests = []
         UNUserNotificationCenter.shared.requests = []
     }
@@ -15,6 +17,18 @@ extension LiveContainerAutoRefreshScheduler {
         defaults.set(Date().addingTimeInterval(3600), forKey: earliestEligibleKey)
         await execute(source: "bgprocessing", task: noOp)
         precondition(LiveContainerRefreshBridge.calls == 0 && noOp.completions == [true])
+        precondition(LiveContainerNetworkPreflight.checks == 0)
+
+        for (code, state) in [(1, "WIFI_UNAVAILABLE"), (2, "VPN_UNAVAILABLE")] {
+            clearTestState()
+            defaults.set(true, forKey: enabledKey)
+            LiveContainerNetworkPreflight.error = NSError(domain: "LiveContainerRefresh.Network", code: code)
+            let blocked = BGTask()
+            await execute(source: "bgprocessing", task: blocked)
+            precondition(LiveContainerRefreshBridge.calls == 0 && blocked.completions == [false])
+            precondition(defaults.string(forKey: healthStateKey) == state)
+            precondition(defaults.object(forKey: nextRetryKey) is Date)
+        }
 
         clearTestState()
         let disabled = BGTask()

--- a/tests/fixtures/livecontainer_scheduler_stubs.swift
+++ b/tests/fixtures/livecontainer_scheduler_stubs.swift
@@ -1,6 +1,15 @@
 // Test doubles for the OS APIs. These verify our Swift types and coordinator
 // behavior, NOT iOS delivery, transport, signing, or physical-device execution.
 import Foundation
+@MainActor enum LiveContainerNetworkPreflight {
+    static var error: Error?
+    static var checks = 0
+    static func check(allowForegroundActivation: Bool) async throws {
+        checks += 1
+        if let error { throw error }
+    }
+    static func consumePendingReturn() -> Bool { false }
+}
 class BGTask {
     var expirationHandler: (() -> Void)?
     var completions: [Bool] = []

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -23,6 +23,31 @@ FILES = ["AltStore/AppDelegate.swift", "AltStore/SceneDelegate.swift",
 
 
 class AutomationTests(unittest.TestCase):
+    def test_auth_preflight_accepts_upstream_credential_paths(self):
+        source = (ROOT / "scripts/patch_background_automation.py").read_text(encoding="utf-8")
+        self.assertNotIn("guard AuthManager.shared.isAuthenticated else", source)
+        expressions = {}
+        for name in ("hasPasswordCredentials", "hasTokenCredentials", "hasReusableSession"):
+            expressions[name] = source.split("let " + name + " = ", 1)[1].splitlines()[0]
+        keys = ("auth.currentAppleID", "auth.hasStoredPassword", "auth.adsid",
+                "auth.hasStoredXcodeToken", "auth.session", "auth.team",
+                "CertificateManager.shared.activeCertificate")
+        def accepted(*present):
+            for expression in expressions.values():
+                expression = expression.replace(" != nil", "")
+                for key in keys:
+                    expression = expression.replace(key, str(key in present))
+                if eval(expression.replace("&&", " and "), {"__builtins__": {}}):
+                    return True
+            return False
+        self.assertTrue(accepted("auth.adsid", "auth.hasStoredXcodeToken"))
+        self.assertTrue(accepted("auth.currentAppleID", "auth.hasStoredPassword"))
+        self.assertTrue(accepted("auth.session", "auth.team", "CertificateManager.shared.activeCertificate"))
+        self.assertFalse(accepted())
+        self.assertFalse(accepted("auth.currentAppleID"))
+        self.assertFalse(accepted("auth.hasStoredXcodeToken"))
+        self.assertFalse(accepted("auth.session", "auth.team"))
+
     def test_scheduled_refresh_selection_contract(self):
         source = (ROOT / "scripts/patch_background_automation.py").read_text(encoding="utf-8")
         self.assertIn("InstalledApp.fetchAppsForBackgroundRefresh(in: context)", source)

--- a/tests/test_embedded_keychain.py
+++ b/tests/test_embedded_keychain.py
@@ -1,0 +1,275 @@
+"""Execute the shipped migration/adapter with isolated Keychain and Security doubles.
+
+These tests verify routing, persistence semantics and OSStatus handling, not
+real iOS securityd entitlement enforcement. The full iOS build typechecks it.
+"""
+from pathlib import Path
+import importlib.util
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "scripts/templates/embedded_shared_keychain.swift"
+SPEC = importlib.util.spec_from_file_location("embedded_keychain_patch", ROOT / "scripts/patch_embedded_keychain.py")
+module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(module)
+
+DOUBLES = r'''
+import Foundation
+// In-memory namespace isolation; each client pins its group at construction.
+enum Store {
+    static var group: String? = "group.example.shared"
+    static var processGroup = "TEAM.host.default"
+    static var data: [String: [String: Data]] = [:]
+    static var failure = 0
+    static var writes = 0
+    static var logs: [String] = []
+}
+func debugLog(_ message: String) { Store.logs.append(message) }
+extension Bundle {
+    enum Info { static var appbundleIdentifier = "com.kdt.livecontainer" }
+    var altstoreAppGroup: String? { Store.group }
+}
+enum KeychainAccess {
+    final class Keychain {
+        enum Accessibility { case afterFirstUnlock }
+        let group: String
+        init(service: String) { group = Store.processGroup }
+        init(service: String, accessGroup: String) { group = accessGroup }
+        func accessibility(_ value: Accessibility) -> Keychain { self }
+        func synchronizable(_ value: Bool) -> Keychain { self }
+        func getData(_ key: String) throws -> Data? {
+            if Store.failure != 0 { throw NSError(domain: NSOSStatusErrorDomain, code: Store.failure) }
+            return Store.data[group]?[key]
+        }
+        func set(_ value: Data, key: String) throws {
+            if Store.failure != 0 { throw NSError(domain: NSOSStatusErrorDomain, code: Store.failure) }
+            Store.data[group, default: [:]][key] = value; Store.writes += 1
+        }
+        func remove(_ key: String) throws {
+            if Store.failure != 0 { throw NSError(domain: NSOSStatusErrorDomain, code: Store.failure) }
+            Store.data[group]?.removeValue(forKey: key); Store.writes += 1
+        }
+        func allKeys() -> [String] { Array(Store.data[group, default: [:]].keys) }
+    }
+}
+typealias CFTypeRef = AnyObject
+typealias CFDictionary = [String: Any]
+let kSecClass = "class", kSecClassGenericPassword = "genp", kSecAttrService = "svce"
+let kSecAttrSynchronizable = "sync", kSecAttrSynchronizableAny = "any"
+let kSecMatchLimit = "limit", kSecMatchLimitAll = "all", kSecReturnAttributes = "attrs"
+let kSecReturnData = "r_Data", kSecUseAuthenticationUI = "ui", kSecUseAuthenticationUIFail = "fail"
+let kSecAttrAccessGroup = "agrp", kSecAttrAccount = "acct", kSecValueData = "v_Data"
+let errSecItemNotFound = -25300, errSecSuccess = 0
+func SecItemCopyMatching(_ query: CFDictionary, _ result: UnsafeMutablePointer<CFTypeRef?>) -> Int {
+    precondition(query[kSecAttrService] as? String == "com.kdt.livecontainer")
+    precondition(query[kSecClass] as? String == kSecClassGenericPassword)
+    precondition(query[kSecUseAuthenticationUI] as? String == kSecUseAuthenticationUIFail)
+    if Store.failure != 0 { return Store.failure }
+    let visible = [Store.processGroup, Store.group ?? ""]
+    var rows: [[String: Any]] = []
+    for group in visible {
+        for (key, value) in Store.data[group, default: [:]] {
+            rows.append([kSecAttrAccessGroup: group, kSecAttrAccount: key, kSecValueData: value])
+        }
+    }
+    if rows.isEmpty { return errSecItemNotFound }
+    result.pointee = rows as NSArray
+    return 0
+}
+'''
+
+HARNESS = r'''
+@main struct Tests {
+    static func main() throws {
+        let scenario = CommandLine.arguments[1]
+        let group = Store.group!
+        let login = ["appleIDAdsid": Data("test-account-id".utf8), "appleIDXcodeToken": Data("sensitive-test-token".utf8)]
+        func seed() { Store.data[Store.processGroup] = login }
+        switch scenario {
+        case "shared_route":
+            seed()
+            let ui = LCEmbeddedSharedKeychain.makeClient()
+            LCEmbeddedSharedKeychain.prepare(ui)
+            precondition(ui.group == group)
+            precondition(LCEmbeddedSharedKeychain.read("appleIDXcodeToken", client: ui) == login["appleIDXcodeToken"])
+            Store.processGroup = "TEAM.LiveProcess.default"
+            let refresh = LCEmbeddedSharedKeychain.makeClient()
+            LCEmbeddedSharedKeychain.prepare(refresh)
+            precondition(refresh.group == group)
+            precondition(LCEmbeddedSharedKeychain.read("appleIDXcodeToken", client: refresh) == login["appleIDXcodeToken"])
+            precondition(Store.data["TEAM.host.default"] == login) // original unchanged
+        case "extension_first":
+            Store.data["TEAM.host.default"] = login
+            Store.processGroup = "TEAM.LiveProcess.default"
+            let refresh = LCEmbeddedSharedKeychain.makeClient()
+            LCEmbeddedSharedKeychain.prepare(refresh)
+            precondition(Store.writes == 0)
+            precondition(LCEmbeddedSharedKeychain.read("appleIDXcodeToken", client: refresh) == nil)
+            Store.processGroup = "TEAM.host.default"
+            let ui = LCEmbeddedSharedKeychain.makeClient()
+            LCEmbeddedSharedKeychain.prepare(ui)
+            precondition(LCEmbeddedSharedKeychain.read("appleIDXcodeToken", client: refresh) == login["appleIDXcodeToken"])
+        case "no_password_or_token_logging":
+            seed(); let client = LCEmbeddedSharedKeychain.makeClient(); LCEmbeddedSharedKeychain.prepare(client)
+            _ = LCEmbeddedSharedKeychain.read("appleIDXcodeToken", client: client)
+            LCEmbeddedSharedKeychain.write("appleIDPassword", data: Data("private-test-password".utf8), client: client)
+            let logs = Store.logs.joined(separator: "\n")
+            for secret in ["sensitive-test-token", "private-test-password", "test-account-id"] { precondition(!logs.contains(secret)) }
+        case "locked":
+            let client = LCEmbeddedSharedKeychain.makeClient(); Store.failure = -25308
+            LCEmbeddedSharedKeychain.prepare(client)
+            precondition(LCEmbeddedSharedKeychain.read("appleIDAdsid", client: client) == nil)
+            let error = LCEmbeddedSharedKeychain.authenticationFailure()
+            precondition(error.domain == "com.SideStore.Keychain" && error.code == 1005)
+            precondition(Store.writes == 0)
+        case "missing_entitlement":
+            let client = LCEmbeddedSharedKeychain.makeClient(); Store.failure = -34018
+            LCEmbeddedSharedKeychain.prepare(client)
+            _ = LCEmbeddedSharedKeychain.read("appleIDAdsid", client: client)
+            precondition(LCEmbeddedSharedKeychain.authenticationFailure().code == 1006)
+        case "missing_group":
+            Store.group = nil
+            let client = LCEmbeddedSharedKeychain.makeClient()
+            LCEmbeddedSharedKeychain.write("appleIDPassword", data: Data("secret".utf8), client: client)
+            precondition(Store.writes == 0 && LCEmbeddedSharedKeychain.authenticationFailure().code == 1006)
+        case "wrong_identity":
+            Bundle.Info.appbundleIdentifier = "com.SideStore.SideStore"
+            let client = LCEmbeddedSharedKeychain.makeClient()
+            LCEmbeddedSharedKeychain.write("appleIDPassword", data: Data("secret".utf8), client: client)
+            precondition(Store.writes == 0 && LCEmbeddedSharedKeychain.authenticationFailure().code == 1006)
+        case "signout_no_resurrection":
+            seed(); let client = LCEmbeddedSharedKeychain.makeClient(); LCEmbeddedSharedKeychain.prepare(client)
+            for key in LCSharedKeychainMigration.authKeys { LCEmbeddedSharedKeychain.write(key, data: nil, client: client) }
+            LCEmbeddedSharedKeychain.prepare(client)
+            precondition(LCEmbeddedSharedKeychain.read("appleIDXcodeToken", client: client) == nil)
+            precondition(Store.data[Store.processGroup] == login)
+        case "clear_all_no_resurrection":
+            seed(); let client = LCEmbeddedSharedKeychain.makeClient(); LCEmbeddedSharedKeychain.prepare(client)
+            LCEmbeddedSharedKeychain.clearAll(client); LCEmbeddedSharedKeychain.prepare(client)
+            precondition(Store.data[group] == [LCSharedKeychainMigration.marker: LCSharedKeychainMigration.ready])
+            precondition(Store.data[Store.processGroup] == login)
+        case "unchanged_no_writes":
+            seed(); let client = LCEmbeddedSharedKeychain.makeClient(); LCEmbeddedSharedKeychain.prepare(client)
+            Store.writes = 0
+            for _ in 0..<50 { LCEmbeddedSharedKeychain.prepare(client); _ = LCEmbeddedSharedKeychain.read("appleIDAdsid", client: client) }
+            precondition(Store.writes == 0)
+        case "partial_retry":
+            let client = LCEmbeddedSharedKeychain.makeClient()
+            let items = login.map { LCLegacyKeychainItem(group: "old", key: $0.key, data: $0.value) }
+            var fail = true
+            do {
+                _ = try LCSharedKeychainMigration.prepare(group: group, items: { items }, read: { try client.getData($0) }, write: { key, data in
+                    if fail && key == "appleIDXcodeToken" { throw NSError(domain: NSOSStatusErrorDomain, code: -25308) }
+                    try client.set(data, key: key)
+                })
+                fatalError("failure was swallowed")
+            } catch {}
+            precondition(LCEmbeddedSharedKeychain.read("appleIDAdsid", client: client) == nil) // uncommitted, not a partial login
+            let uncommittedMarker = try client.getData(LCSharedKeychainMigration.marker)
+            precondition(uncommittedMarker == nil)
+            fail = false
+            let ready = try LCSharedKeychainMigration.prepare(group: group, items: { items }, read: { try client.getData($0) }, write: { try client.set($1, key: $0) })
+            precondition(ready && LCEmbeddedSharedKeychain.read("appleIDXcodeToken", client: client) == login["appleIDXcodeToken"])
+        case "conflicts_fail_before_writes":
+            let client = LCEmbeddedSharedKeychain.makeClient()
+            var items = login.map { LCLegacyKeychainItem(group: "old1", key: $0.key, data: $0.value) }
+            items += [LCLegacyKeychainItem(group: "old2", key: "appleIDAdsid", data: Data("another".utf8)), LCLegacyKeychainItem(group: "old2", key: "appleIDXcodeToken", data: Data("token2".utf8))]
+            do {
+                _ = try LCSharedKeychainMigration.prepare(group: group, items: { items }, read: { try client.getData($0) }, write: { try client.set($1, key: $0) })
+                fatalError("mixed legacy accounts")
+            } catch { precondition((error as NSError).code == 1008) }
+            precondition(Store.writes == 0)
+        case "no_cross_group_pair":
+            let client = LCEmbeddedSharedKeychain.makeClient()
+            let items = [LCLegacyKeychainItem(group: "A", key: "appleIDAdsid", data: Data("id".utf8)), LCLegacyKeychainItem(group: "B", key: "appleIDXcodeToken", data: Data("token".utf8))]
+            let ready = try LCSharedKeychainMigration.prepare(group: group, items: { items }, read: { try client.getData($0) }, write: { try client.set($1, key: $0) })
+            precondition(!ready && Store.writes == 0)
+        case "certificate_only":
+            let cert = Data("test-imported-cert".utf8)
+            Store.data[Store.processGroup] = ["importedCert_test": cert]
+            let client = LCEmbeddedSharedKeychain.makeClient(); LCEmbeddedSharedKeychain.prepare(client)
+            precondition(LCEmbeddedSharedKeychain.read("importedCert_test", client: client) == cert)
+            precondition(LCEmbeddedSharedKeychain.read("appleIDXcodeToken", client: client) == nil)
+            precondition(Store.writes == 0)
+        case "invalid_utf8":
+            seed(); let client = LCEmbeddedSharedKeychain.makeClient(); LCEmbeddedSharedKeychain.prepare(client)
+            Store.data[group]?["appleIDXcodeToken"] = Data([0xff])
+            precondition(LCEmbeddedSharedKeychain.readString("appleIDXcodeToken", client: client) == nil)
+            precondition(LCEmbeddedSharedKeychain.authenticationFailure().code == 1009)
+        case "preserve_new_login":
+            seed(); let client = LCEmbeddedSharedKeychain.makeClient()
+            LCEmbeddedSharedKeychain.write("appleIDAdsid", data: Data("new-id".utf8), client: client)
+            LCEmbeddedSharedKeychain.write("appleIDXcodeToken", data: Data("new-token".utf8), client: client)
+            LCEmbeddedSharedKeychain.prepare(client)
+            precondition(LCEmbeddedSharedKeychain.read("appleIDAdsid", client: client) == Data("new-id".utf8))
+        default: fatalError("unknown scenario")
+        }
+        print("PASSED: " + scenario)
+    }
+}
+'''
+
+class EmbeddedKeychainTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        compiler = shutil.which("swiftc")
+        if not compiler:
+            raise unittest.SkipTest("swiftc unavailable")
+        cls.temp = tempfile.TemporaryDirectory(prefix="lc-keychain-tests-")
+        cls.addClassCleanup(cls.temp.cleanup)
+        source = Path(cls.temp.name) / "KeychainTests.swift"
+        source.write_text(DOUBLES + TEMPLATE.read_text() + HARNESS)
+        cls.executable = Path(cls.temp.name) / "keychain-tests"
+        result = subprocess.run([compiler, "-swift-version", "5", "-parse-as-library", "-O", str(source), "-o", str(cls.executable)], capture_output=True, text=True)
+        if result.returncode:
+            raise AssertionError(result.stderr)
+
+    def test_execution_scenarios(self):
+        for scenario in ("shared_route", "extension_first", "no_password_or_token_logging", "locked", "missing_entitlement", "missing_group", "wrong_identity", "signout_no_resurrection", "clear_all_no_resurrection", "unchanged_no_writes", "partial_retry", "conflicts_fail_before_writes", "no_cross_group_pair", "preserve_new_login", "certificate_only", "invalid_utf8"):
+            with self.subTest(scenario=scenario):
+                result = subprocess.run([str(self.executable), scenario], capture_output=True, text=True)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("PASSED: " + scenario, result.stdout)
+
+    def test_source_safety(self):
+        text = TEMPLATE.read_text()
+        for forbidden in ("UserDefaults.", "write(to:", "NSLog(", "Timer(", "Task.sleep", "removePersistentDomain", "signOut("):
+            self.assertNotIn(forbidden, text)
+        self.assertIn("accessGroup: group", text)
+        self.assertIn("kSecAttrService as String: service", text)
+        self.assertIn("kSecUseAuthenticationUIFail", text)
+        self.assertNotIn("\\(error)", text)
+        self.assertIn(".afterFirstUnlock", text)
+
+    def test_pinned_patch_and_idempotence(self):
+        source = os.environ.get("EMBEDDED_SIDESTORE_TEST_SOURCE")
+        if not source:
+            self.skipTest("pinned SideStore source unavailable locally; required in combined CI")
+        relative = "AltStore/Core/Components/Keychain.swift"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target = root / relative
+            target.parent.mkdir(parents=True)
+            shutil.copy2(Path(source) / relative, target)
+            op = root / "SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift"
+            op.parent.mkdir(parents=True)
+            op.write_text('''func preflight() throws {
+        guard hasPasswordCredentials || hasTokenCredentials || hasReusableSession else {
+            let error = NSError(domain: "com.SideStore.Authentication", code: 1004)
+            debugLog("[AUTO_REFRESH] AUTH_PREFLIGHT_FAIL reason=no_accessible_authentication_path")
+            throw error
+        }
+}''')
+            module.patch(root)
+            first = (target.read_bytes(), op.read_bytes())
+            module.patch(root)
+            self.assertEqual(first, (target.read_bytes(), op.read_bytes()))
+            self.assertIn("Keychain.shared.embeddedAuthenticationFailure()", op.read_text())
+            self.assertNotIn("try? Keychain.shared.keychain.get", target.read_text())
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_embedded_sidestore_startup.py
+++ b/tests/test_embedded_sidestore_startup.py
@@ -32,6 +32,7 @@ class EmbeddedSideStoreStartupTests(unittest.TestCase):
         self.live = root / "LiveContainer"
         self.side = root / "SideStore"
         for source, target in (
+            (side / "SideStore/Core/Auth/AuthManager.swift", self.side / "SideStore/Core/Auth/AuthManager.swift"),
             (live / "SideStoreSupport" / "SideStoreHooks.m", self.live / "SideStoreSupport" / "SideStoreHooks.m"),
             (live / "LiveContainer" / "LCBootstrap.m", self.live / "LiveContainer" / "LCBootstrap.m"),
             (side / "AltStore" / "Core" / "Model" / "DatabaseManager" / "DatabaseManager.swift",
@@ -56,6 +57,15 @@ class EmbeddedSideStoreStartupTests(unittest.TestCase):
         self.assertIn("PrivClass(Source) == nil", hooks)
         self.assertIn("hooks_deferred", hooks)
         self.assertIn("static dispatch_once_t onceToken", hooks)
+        self.assertIn('?: [NSMutableArray array]', hooks)
+        self.assertIn('Return to LiveContainer', hooks)
+        auth = self.text(self.side / "SideStore/Core/Auth/AuthManager.swift")
+        self.assertEqual(auth.count("let matches = Keychain.shared."), 4)
+        self.assertEqual(auth.count('"SAVE_FAILED"'), 4)
+        self.assertNotIn('debugLog("[SAVED]', auth)
+        for line in auth.splitlines():
+            if 'debugLog(' in line and 'readback_matches=' in line:
+                self.assertNotIn('newValue', line)
 
         bootstrap = self.text(self.live / "LiveContainer" / "LCBootstrap.m")
         self.assertIn(MARKER, bootstrap)

--- a/tests/test_guest_return.py
+++ b/tests/test_guest_return.py
@@ -227,6 +227,7 @@ int main(void) {
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copyfile(source / name, dest)
             module.patch(root)
+            self.assertIn('store: UserDefaults.lcUserDefaults()', (root / "LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift").read_text())
             first = {name: (root/name).read_bytes() for name in module.PATHS}
             module.patch(root)
             self.assertEqual(first, {name: (root/name).read_bytes() for name in module.PATHS})

--- a/tests/test_guest_return.py
+++ b/tests/test_guest_return.py
@@ -149,6 +149,18 @@ class GuestReturnTests(unittest.TestCase):
         for forbidden in ("NSTimer", "dispatch_after", "sleep("):
             self.assertNotIn(forbidden, module.CONTROL)
 
+    def test_direct_control_is_separate_and_honest(self):
+        self.assertIn("Restarts LiveContainer and closes this guest", module.DIRECT_CONTROL)
+        self.assertIn("DIRECT_PROCESS_RESTART_RETURN", module.DIRECT_RUNTIME)
+        self.assertIn("launchToGuestAppWithClassicMode:0", module.DIRECT_RUNTIME)
+        self.assertIn("UIWindowDidBecomeVisibleNotification", module.DIRECT_RUNTIME)
+        self.assertIn("UISceneDidDisconnectNotification", module.DIRECT_RUNTIME)
+        self.assertIn("window.hidden = NO", module.DIRECT_RUNTIME)
+        self.assertNotIn("makeKeyAndVisible", module.DIRECT_RUNTIME)
+        self.assertNotIn("launchToGuestApp", module.METHODS)
+        for forbidden in ("NSTimer", "dispatch_after", "SIGKILL", "terminate", "sleep("):
+            self.assertNotIn(forbidden, module.DIRECT_RUNTIME)
+
     def test_cleanup_finishes_before_exit_callback(self):
         self.assertLess(module.CLEANUP.index("unregisterMultitaskContainer"), module.CLEANUP.index("appSceneVCAppDidExit"))
         self.assertIn("NSThread.isMainThread", module.CLEANUP)

--- a/tests/test_guest_return.py
+++ b/tests/test_guest_return.py
@@ -136,6 +136,17 @@ SWIFT_TESTS = r'''
 '''
 
 class GuestReturnTests(unittest.TestCase):
+    def test_virtual_control_is_above_chrome_and_native_stays_local(self):
+        self.assertIn('[(DecoratedAppSceneViewController *)self.delegate view] : self.view', module.METHODS)
+        self.assertIn('[overlayHost addSubview:self.lcReturnControl]', module.METHODS)
+        self.assertIn('[overlayHost bringSubviewToFront:self.lcReturnControl]', module.METHODS)
+        self.assertIn('convertRect:self.view.bounds toView:overlayHost', module.METHODS)
+        self.assertIn('self.lcReturnControl.superview != overlayHost', module.METHODS)
+        self.assertIn('self.lcReturnControl.hidden = !self.isAppRunning', module.METHODS)
+        self.assertNotIn('[self.view addSubview:self.lcReturnControl]', module.METHODS)
+        self.assertLess(module.METHODS.index('if (self.isAppTerminationCleanUpCalled)'), module.METHODS.index('[overlayHost addSubview:'))
+        self.assertIn('[self.lcReturnControl removeFromSuperview]', module.CLEANUP)
+
     def test_preservation_has_no_termination_or_new_session(self):
         self.assertIn("minimizeWindow", module.METHODS)
         self.assertIn("self.lcActivateHost()", module.METHODS)

--- a/tests/test_guest_return.py
+++ b/tests/test_guest_return.py
@@ -142,10 +142,16 @@ class GuestReturnTests(unittest.TestCase):
         self.assertIn('[overlayHost bringSubviewToFront:self.lcReturnControl]', module.METHODS)
         self.assertIn('convertRect:self.view.bounds toView:overlayHost', module.METHODS)
         self.assertIn('self.lcReturnControl.superview != overlayHost', module.METHODS)
-        self.assertIn('self.lcReturnControl.hidden = !self.isAppRunning', module.METHODS)
+        self.assertIn('self.lcReturnControl.hidden = LCReturnShouldHide(self.isAppRunning, decorated, maximized)', module.METHODS)
         self.assertNotIn('[self.view addSubview:self.lcReturnControl]', module.METHODS)
         self.assertLess(module.METHODS.index('if (self.isAppTerminationCleanUpCalled)'), module.METHODS.index('[overlayHost addSubview:'))
         self.assertIn('[self.lcReturnControl removeFromSuperview]', module.CLEANUP)
+
+    def test_windowed_visibility_does_not_change_global_preference(self):
+        self.assertIn('[(DecoratedAppSceneViewController *)self.delegate isMaximized]', module.METHODS)
+        self.assertIn('return !running || (decorated && !maximized)', module.GEOMETRY)
+        self.assertNotIn('setBool:', module.METHODS)
+        self.assertNotIn('LCHideReturnControl', module.METHODS)
 
     def test_preservation_has_no_termination_or_new_session(self):
         self.assertIn("minimizeWindow", module.METHODS)
@@ -204,6 +210,14 @@ class GuestReturnTests(unittest.TestCase):
         if not compiler: self.skipTest("C compiler unavailable")
         source = "#include <math.h>\n#include <assert.h>\n" + module.GEOMETRY + r'''
 int main(void) {
+    for (int running = 0; running <= 1; running++) {
+        for (int decorated = 0; decorated <= 1; decorated++) {
+            for (int maximized = 0; maximized <= 1; maximized++) {
+                assert(LCReturnShouldHide(running, decorated, maximized) ==
+                       (!running || (decorated && !maximized)));
+            }
+        }
+    }
     for (int size = 44; size <= 2000; size += 7) {
         for (int p = -2; p <= 3; p++) {
             double center = LCReturnAxisCenter(9, size, p);
@@ -248,6 +262,9 @@ int main(void) {
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copyfile(source / name, dest)
             module.patch(root)
+            decorated = (root / "MultitaskSupport/DecoratedAppSceneViewController.m").read_text()
+            for state in ("YES", "NO"):
+                self.assertIn(f"self.isMaximized = {state};\n            [self.appSceneVC.view setNeedsLayout];", decorated)
             # The Objective-C lcUserDefaults factory is imported into Swift as lc().
             self.assertIn('store: UserDefaults.lc()', (root / "LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift").read_text())
             first = {name: (root/name).read_bytes() for name in module.PATHS}

--- a/tests/test_guest_return.py
+++ b/tests/test_guest_return.py
@@ -1,7 +1,9 @@
-"""Verify patches against pinned runtime sources and preservation boundaries."""
+"""Execute the actual injected registry and geometry; validate pinned patches in CI."""
 import importlib.util
+import os
 from pathlib import Path
 import shutil
+import subprocess
 import tempfile
 import unittest
 
@@ -10,46 +12,218 @@ spec = importlib.util.spec_from_file_location("guest_return", ROOT / "scripts/pa
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 
+SWIFT_STUBS = r'''
+import Foundation
+final class UISceneSession: NSObject {
+    let persistentIdentifier: String
+    init(_ id: String) { persistentIdentifier = id }
+}
+final class UIApplication {
+    static let shared = UIApplication()
+    var openSessions: Set<UISceneSession> = []
+    var activated: [String] = []
+    func requestSceneSessionActivation(_ session: UISceneSession?, userActivity: Any?, options: Any?, errorHandler: ((Error)->Void)?) {
+        if let session { activated.append(session.persistentIdentifier) }
+    }
+}
+final class SharedModel { var enableMultipleWindow = false }
+final class DataManager {
+    static let shared = DataManager()
+    let model = SharedModel()
+}
+final class AppSceneViewController: NSObject {
+    var pid: Int32
+    var isAppRunning = true
+    var cleanupCount = 0
+    var exit: (() -> Void)?
+    init(_ pid: Int32) { self.pid = pid }
+    func appTerminationCleanUp() {
+        cleanupCount += 1
+        isAppRunning = false
+        exit?()
+    }
+}
+struct MultitaskAppInfo {
+    var displayName: String
+    var dataUUID: String
+    var bundleId: String
+    let windowID = UUID().uuidString
+    var pid: Int32 = 0
+    weak var controller: AppSceneViewController?
+    var launchCallback: ((NSNumber, Error?) -> Void)?
+}
+class MultitaskWindowManager: NSObject {
+    static var appDict: [String: MultitaskAppInfo] = [:]
+    static var opened: [(String, String)] = []
+    static func openWindow(id: String, value: String) { opened.append((id, value)) }
+'''
+
+SWIFT_TESTS = r'''
+}
+@main struct Tests {
+    static func main() {
+        typealias M = MultitaskWindowManager
+        func launch(_ id: String, _ callback: @escaping (NSNumber, Error?)->Void) -> String {
+            M.openAppWindow(displayName: id, dataUUID: id, bundleId: "app." + id, pidCallback: callback)
+            return M.appDict.first(where: { $0.value.dataUUID == id })!.key
+        }
+        var results: [String: Int] = [:]
+        let a = launch("A") { p, e in precondition(e == nil); results["A"] = p.intValue }
+        let b = launch("B") { p, e in precondition(e == nil); results["B"] = p.intValue }
+        precondition(a != b && a != "A" && b != "B")
+        let ca = AppSceneViewController(101), cb = AppSceneViewController(202)
+        M.bind(ca, windowID: a); M.bind(cb, windowID: b)
+        // Reverse completion order must not swap callbacks or drop either result.
+        M.initialized(cb, windowID: b, error: nil)
+        M.initialized(ca, windowID: a, error: nil)
+        precondition(results == ["A": 101, "B": 202])
+        precondition(M.appDict[a]?.launchCallback == nil)
+        precondition(M.openExistingAppWindow(dataUUID: "A"))
+        precondition(M.opened.last!.1 == a)
+        precondition(ca.cleanupCount == 0 && cb.cleanupCount == 0)
+        var duplicateError = 0
+        M.openAppWindow(displayName: "A", dataUUID: "A", bundleId: "app.A") { _, e in
+            precondition(e != nil); duplicateError += 1
+        }
+        precondition(duplicateError == 1 && M.appDict.count == 2)
+        // Minimized process death: cleanup before replacement, not a kill/relaunch of a live guest.
+        ca.exit = { M.exited(ca, windowID: a) }
+        ca.isAppRunning = false
+        precondition(!M.openExistingAppWindow(dataUUID: "A"))
+        precondition(ca.cleanupCount == 1 && M.appDict[a] == nil)
+        var newCalls = 0
+        let newA = launch("A") { _, e in precondition(e == nil); newCalls += 1 }
+        precondition(newA != a)
+        let newCA = AppSceneViewController(303)
+        M.bind(newCA, windowID: newA)
+        M.initialized(ca, windowID: a, error: nil) // Old completion must not touch new launch.
+        M.exited(ca, windowID: a)
+        precondition(M.appDict[newA] != nil && newCalls == 0)
+        M.initialized(newCA, windowID: newA, error: nil)
+        M.initialized(newCA, windowID: newA, error: nil)
+        precondition(newCalls == 1)
+        // Pending launch and zero PID are not declared dead.
+        var pendingErrors = 0
+        let pending = launch("pending") { _, e in if e != nil { pendingErrors += 1 } }
+        precondition(M.openExistingAppWindow(dataUUID: "pending"))
+        let pendingC = AppSceneViewController(0)
+        M.bind(pendingC, windowID: pending)
+        M.exited(pendingC, windowID: pending)
+        M.exited(pendingC, windowID: pending)
+        precondition(pendingErrors == 1 && M.appDict[pending] == nil)
+        // Initializer failure must release this exact launch and propagate once.
+        var failureCalls = 0
+        let failed = launch("failed") { _, e in precondition(e != nil); failureCalls += 1 }
+        let failedC = AppSceneViewController(0)
+        M.bind(failedC, windowID: failed)
+        failedC.exit = { M.exited(failedC, windowID: failed) }
+        M.initialized(failedC, windowID: failed, error: NSError(domain: "test", code: 1))
+        precondition(failureCalls == 1 && M.appDict[failed] == nil)
+        // Activating host must target its real session; only create when missing.
+        var creations = 0
+        let main = UISceneSession("main")
+        UIApplication.shared.openSessions = [main]
+        M.mainSceneSession = main
+        M.activateMainScene { creations += 1 }
+        precondition(UIApplication.shared.activated == ["main"] && creations == 0)
+        UIApplication.shared.openSessions = []
+        M.activateMainScene { creations += 1 }
+        precondition(creations == 1 && M.mainSceneSession == nil)
+        precondition(cb.cleanupCount == 0 && newCA.cleanupCount == 0)
+        print("REGISTRY_RUNTIME_TESTS_PASSED")
+    }
+}
+'''
 
 class GuestReturnTests(unittest.TestCase):
     def test_preservation_has_no_termination_or_new_session(self):
-        code = module.METHODS
-        self.assertIn("minimizeWindow", code)
-        self.assertIn("self.lcActivateHost()", code)
+        self.assertIn("minimizeWindow", module.METHODS)
+        self.assertIn("self.lcActivateHost()", module.METHODS)
         for forbidden in ("terminate]", "SIGKILL", "raise(", "launchToGuestApp", "NSExtension", "removeObjectForKey"):
-            self.assertNotIn(forbidden, code)
+            self.assertNotIn(forbidden, module.METHODS)
 
     def test_control_is_event_driven_and_touch_transparent(self):
-        self.assertIn("return hit == self ? nil : hit", module.CONTROL)
-        self.assertIn("UIGestureRecognizerStateEnded", module.CONTROL)
-        self.assertIn("isfinite(x)", module.CONTROL)
-        self.assertIn("self.safeAreaInsets", module.CONTROL)
-        self.assertIn("UIKeyboardWillChangeFrameNotification", module.CONTROL)
+        for required in ("return hit == self ? nil : hit", "UIGestureRecognizerStateEnded", "isfinite(x)",
+                         "self.safeAreaInsets", "UIKeyboardWillChangeFrameNotification", "rect.size.width < 44"):
+            self.assertIn(required, module.CONTROL)
         for forbidden in ("NSTimer", "dispatch_after", "sleep("):
             self.assertNotIn(forbidden, module.CONTROL)
 
+    def test_cleanup_finishes_before_exit_callback(self):
+        self.assertLess(module.CLEANUP.index("unregisterMultitaskContainer"), module.CLEANUP.index("appSceneVCAppDidExit"))
+        self.assertIn("NSThread.isMainThread", module.CLEANUP)
+        self.assertNotIn("_kill", module.CLEANUP)
+        self.assertNotIn("connectedScenes.first", module.DOCK_RESUME)
+        self.assertIn("targetView.window", module.DOCK_RESUME)
+
+    def test_registry_uses_generation_and_own_callback(self):
+        self.assertNotIn("DataManager.shared.model.pidCallback", module.WINDOW_MANAGER)
+        self.assertIn("entry.windowID", module.WINDOW_MANAGER)
+        self.assertLess(module.WINDOW_MANAGER.index("entry.launchCallback = nil"), module.WINDOW_MANAGER.index("callback?("))
+        self.assertNotIn("unregisterMultitaskContainer", module.WINDOW_MANAGER)
+        self.assertNotIn("getpgid", module.WINDOW_MANAGER)
+
+    def test_geometry_executes_for_resize_and_invalid_position(self):
+        compiler = shutil.which("cc")
+        if not compiler: self.skipTest("C compiler unavailable")
+        source = "#include <math.h>\n#include <assert.h>\n" + module.GEOMETRY + r'''
+int main(void) {
+    for (int size = 44; size <= 2000; size += 7) {
+        for (int p = -2; p <= 3; p++) {
+            double center = LCReturnAxisCenter(9, size, p);
+            assert(center - 22 >= 9 && center + 22 <= 9 + size);
+        }
+    }
+    assert(LCReturnAxisCenter(0, 44, 1) == 22);
+    assert(LCReturnAxisCenter(0, 10, 1) == 5);
+    assert(isfinite(LCReturnAxisCenter(0, 300, NAN)));
+    assert(LCReturnAxisCenter(NAN, 300, 0.2) == 0);
+    assert(LCReturnAxisCenter(0, INFINITY, 0.2) == 0);
+    return 0;
+}
+'''
+        with tempfile.TemporaryDirectory() as directory:
+            src, exe = Path(directory)/"geometry.c", Path(directory)/"geometry"
+            src.write_text(source)
+            subprocess.run([compiler, "-Wall", "-Wextra", "-Werror", str(src), "-lm", "-o", str(exe)], check=True, capture_output=True)
+            subprocess.run([str(exe)], check=True, capture_output=True)
+
+    def test_registry_executes_real_injected_code(self):
+        compiler = shutil.which("swiftc")
+        if not compiler: self.skipTest("Swift compiler unavailable")
+        # Only remove Objective-C exposure for Linux. Registry bodies are the shipped code.
+        source = SWIFT_STUBS + module.WINDOW_MANAGER.replace("@objc ", "") + SWIFT_TESTS
+        with tempfile.TemporaryDirectory() as directory:
+            src, exe = Path(directory)/"Registry.swift", Path(directory)/"registry"
+            src.write_text(source)
+            build = subprocess.run([compiler, "-parse-as-library", "-swift-version", "5", "-O", str(src), "-o", str(exe)], capture_output=True, text=True)
+            self.assertEqual(build.returncode, 0, build.stderr)
+            run = subprocess.run([str(exe)], capture_output=True, text=True)
+            self.assertEqual(run.returncode, 0, run.stderr)
+            self.assertIn("REGISTRY_RUNTIME_TESTS_PASSED", run.stdout)
+
     def test_pinned_patch_and_idempotence(self):
-        source = ROOT / ".audit/upstream/LiveContainer"
-        if not source.exists():
-            self.skipTest("Pinned LiveContainer source unavailable")
-        paths = ("MultitaskSupport/AppSceneViewController.m", "MultitaskSupport/AppSceneViewController.h",
-                 "MultitaskSupport/MultitaskAppWindow.swift", "MultitaskSupport/MultitaskDockView.swift",
-                 "SideStoreSupport/SideStoreHooks.m", "LiveContainerSwiftUI/Models/LCAppModel.swift")
+        source = Path(os.environ.get("LIVE_CONTAINER_TEST_SOURCE", str(ROOT / ".audit/upstream/LiveContainer")))
+        if not source.is_dir(): self.skipTest("Pinned LiveContainer source unavailable")
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            for name in paths:
+            for name in module.PATHS:
                 dest = root / name
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copyfile(source / name, dest)
             module.patch(root)
-            first = {name: (root / name).read_bytes() for name in paths}
+            first = {name: (root/name).read_bytes() for name in module.PATHS}
             module.patch(root)
-            self.assertEqual(first, {name: (root / name).read_bytes() for name in paths})
-            window = (root / paths[2]).read_text()
-            self.assertIn('returnOpenWindow(id: "Main")', window)
-            self.assertIn("getpgid(a.value.pid)", window)
-            self.assertIn("appDict[appInfo.dataUUID]?.pid = pid", window)
+            self.assertEqual(first, {name: (root/name).read_bytes() for name in module.PATHS})
+            compiler = shutil.which("swiftc")
+            if compiler:
+                for name in module.PATHS:
+                    if name.endswith(".swift"):
+                        result = subprocess.run([compiler, "-frontend", "-parse", str(root/name)], text=True, capture_output=True)
+                        self.assertEqual(result.returncode, 0, name + result.stderr)
+            # No partial write when one pinned anchor drifts.
+            broken = root / module.PATHS[0]
+            broken.write_text(broken.read_text().replace("LCReturnControl", "UnexpectedControl"))
+            with self.assertRaises(ValueError): module.patch(root)
 
-
-if __name__ == "__main__":
-    unittest.main()
+if __name__ == "__main__": unittest.main()

--- a/tests/test_guest_return.py
+++ b/tests/test_guest_return.py
@@ -227,7 +227,8 @@ int main(void) {
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copyfile(source / name, dest)
             module.patch(root)
-            self.assertIn('store: UserDefaults.lcUserDefaults()', (root / "LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift").read_text())
+            # The Objective-C lcUserDefaults factory is imported into Swift as lc().
+            self.assertIn('store: UserDefaults.lc()', (root / "LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift").read_text())
             first = {name: (root/name).read_bytes() for name in module.PATHS}
             module.patch(root)
             self.assertEqual(first, {name: (root/name).read_bytes() for name in module.PATHS})

--- a/tests/test_guest_return.py
+++ b/tests/test_guest_return.py
@@ -1,0 +1,55 @@
+"""Verify patches against pinned runtime sources and preservation boundaries."""
+import importlib.util
+from pathlib import Path
+import shutil
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("guest_return", ROOT / "scripts/patch_guest_return.py")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class GuestReturnTests(unittest.TestCase):
+    def test_preservation_has_no_termination_or_new_session(self):
+        code = module.METHODS
+        self.assertIn("minimizeWindow", code)
+        self.assertIn("self.lcActivateHost()", code)
+        for forbidden in ("terminate]", "SIGKILL", "raise(", "launchToGuestApp", "NSExtension", "removeObjectForKey"):
+            self.assertNotIn(forbidden, code)
+
+    def test_control_is_event_driven_and_touch_transparent(self):
+        self.assertIn("return hit == self ? nil : hit", module.CONTROL)
+        self.assertIn("UIGestureRecognizerStateEnded", module.CONTROL)
+        self.assertIn("isfinite(x)", module.CONTROL)
+        self.assertIn("self.safeAreaInsets", module.CONTROL)
+        self.assertIn("UIKeyboardWillChangeFrameNotification", module.CONTROL)
+        for forbidden in ("NSTimer", "dispatch_after", "sleep("):
+            self.assertNotIn(forbidden, module.CONTROL)
+
+    def test_pinned_patch_and_idempotence(self):
+        source = ROOT / ".audit/upstream/LiveContainer"
+        if not source.exists():
+            self.skipTest("Pinned LiveContainer source unavailable")
+        paths = ("MultitaskSupport/AppSceneViewController.m", "MultitaskSupport/AppSceneViewController.h",
+                 "MultitaskSupport/MultitaskAppWindow.swift", "MultitaskSupport/MultitaskDockView.swift",
+                 "SideStoreSupport/SideStoreHooks.m", "LiveContainerSwiftUI/Models/LCAppModel.swift")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for name in paths:
+                dest = root / name
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(source / name, dest)
+            module.patch(root)
+            first = {name: (root / name).read_bytes() for name in paths}
+            module.patch(root)
+            self.assertEqual(first, {name: (root / name).read_bytes() for name in paths})
+            window = (root / paths[2]).read_text()
+            self.assertIn('returnOpenWindow(id: "Main")', window)
+            self.assertIn("getpgid(a.value.pid)", window)
+            self.assertIn("appDict[appInfo.dataUUID]?.pid = pid", window)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_guest_return.py
+++ b/tests/test_guest_return.py
@@ -150,6 +150,9 @@ class GuestReturnTests(unittest.TestCase):
             self.assertNotIn(forbidden, module.CONTROL)
 
     def test_direct_control_is_separate_and_honest(self):
+        self.assertIn('Hide Return Button', module.CONTROL)
+        self.assertIn('boolForKey:@"LCHideReturnControl"', module.CONTROL)
+        self.assertIn('LCHideReturnControl', module.DIRECT_CONTROL)
         self.assertIn("Restarts LiveContainer and closes this guest", module.DIRECT_CONTROL)
         self.assertIn("DIRECT_PROCESS_RESTART_RETURN", module.DIRECT_RUNTIME)
         self.assertIn("launchToGuestAppWithClassicMode:0", module.DIRECT_RUNTIME)

--- a/tests/test_guest_return.py
+++ b/tests/test_guest_return.py
@@ -150,7 +150,7 @@ class GuestReturnTests(unittest.TestCase):
             self.assertNotIn(forbidden, module.CONTROL)
 
     def test_direct_control_is_separate_and_honest(self):
-        self.assertIn('Hide Return Button', module.CONTROL)
+        self.assertIn('Collapse Return Button', module.CONTROL)
         self.assertIn('boolForKey:@"LCHideReturnControl"', module.CONTROL)
         self.assertIn('LCHideReturnControl', module.DIRECT_CONTROL)
         self.assertIn("Restarts LiveContainer and closes this guest", module.DIRECT_CONTROL)
@@ -163,6 +163,16 @@ class GuestReturnTests(unittest.TestCase):
         self.assertNotIn("launchToGuestApp", module.METHODS)
         for forbidden in ("NSTimer", "dispatch_after", "SIGKILL", "terminate", "sleep("):
             self.assertNotIn(forbidden, module.DIRECT_RUNTIME)
+
+    def test_collapse_does_not_disable_global_preference_or_return(self):
+        for control in (module.CONTROL, module.DIRECT_CONTROL):
+            self.assertNotIn('setBool:YES forKey:@"LCHideReturnControl"', control)
+            self.assertIn('weakControl.collapsed = YES', control)
+            self.assertIn('self.collapsed = NO', control)
+            self.assertIn('CONTROL_RESTORED', control)
+            self.assertIn('chevron.compact.right', control)
+            tapped = control[control.index('- (void)tapped'):]
+            self.assertLess(tapped.index('return;'), tapped.index('self.action()'))
 
     def test_cleanup_finishes_before_exit_callback(self):
         self.assertLess(module.CLEANUP.index("unregisterMultitaskContainer"), module.CLEANUP.index("appSceneVCAppDidExit"))

--- a/tests/test_network_preflight.py
+++ b/tests/test_network_preflight.py
@@ -1,0 +1,47 @@
+"""Source contracts; OS path delivery and URL callbacks still need device tests."""
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+NETWORK = (ROOT / "scripts/templates/livecontainer_network_preflight.swift").read_text()
+SCHEDULER = (ROOT / "scripts/templates/livecontainer_refresh_scheduler.swift").read_text()
+
+
+class NetworkPreflightTests(unittest.TestCase):
+    def test_wifi_is_one_shot_without_ssid_or_location(self):
+        self.assertIn("NWPathMonitor(requiredInterfaceType: .wifi)", NETWORK)
+        self.assertIn("path.status == .satisfied", NETWORK)
+        self.assertIn("monitor.cancel()", NETWORK)
+        for forbidden in ("CNCopyCurrentNetworkInfo", "CLLocationManager", "Timer.scheduledTimer", "Task.sleep"):
+            self.assertNotIn(forbidden, NETWORK)
+
+    def test_no_transport_until_preflight_passes(self):
+        self.assertLess(SCHEDULER.index("try await LiveContainerNetworkPreflight.check"),
+                        SCHEDULER.index("try await performRefresh(runID: runID)"))
+        check = NETWORK[NETWORK.index("static func check("):]
+        self.assertLess(check.index("guard await wifiAvailable()"), check.index("hasTunnelInterface()"))
+        self.assertIn("WIFI_UNAVAILABLE", SCHEDULER)
+        self.assertIn("VPN_UNAVAILABLE", SCHEDULER)
+
+    def test_background_never_launches_vpn(self):
+        self.assertIn('manual && source != "vpn_return" && task == nil', SCHEDULER)
+        self.assertIn("UIApplication.shared.applicationState == .active", NETWORK)
+        self.assertIn("VPN_UNAVAILABLE_BACKGROUND", NETWORK)
+
+    def test_return_is_rechecked_not_assumed_ready(self):
+        self.assertIn('URLQueryItem(name: "scheme", value: scheme)', NETWORK)
+        self.assertIn("wifi_lost_during_activation", NETWORK)
+        self.assertIn("no_utun_interface", NETWORK)
+        self.assertIn("readiness=requires_coredevice_verification", NETWORK)
+        self.assertIn("guard !completed else", NETWORK)
+        self.assertIn("removeObserver", NETWORK)
+
+    def test_durable_handoff_is_bounded_and_consumed_once(self):
+        self.assertIn("age >= 0 && age < 120", NETWORK)
+        self.assertIn("defaults.removeObject(forKey: pendingKey)", NETWORK)
+        self.assertLess(SCHEDULER.index("guard activeRun == nil else { return }", SCHEDULER.index("static func recoverAfterLaunchOrResume")),
+                        SCHEDULER.index("LiveContainerNetworkPreflight.consumePendingReturn()"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_refresh_result_bridge.py
+++ b/tests/test_refresh_result_bridge.py
@@ -1,0 +1,104 @@
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load(name):
+    spec = importlib.util.spec_from_file_location(name, ROOT / "scripts" / (name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+bridge = load("patch_refresh_result_bridge")
+host = load("patch_livecontainer_autorefresh")
+
+
+class RefreshResultBridgeTests(unittest.TestCase):
+    def test_host_result_import_executes(self):
+        compiler = shutil.which("swiftc")
+        if not compiler:
+            self.skipTest("swiftc unavailable; executable XPC result validation requires CI")
+        source = '''import Foundation
+class Host {
+    var c: Int? = 1
+    var completions = 0
+    var lastError: String?
+    func finish(_ error: String?) { completions += 1; lastError = error; c = nil }
+''' + bridge.HOST + r'''
+}
+let defaults = UserDefaults(suiteName: "group.com.SideStore.SideStore")!
+defaults.removePersistentDomain(forName: "group.com.SideStore.SideStore")
+defer { defaults.removePersistentDomain(forName: "group.com.SideStore.SideStore") }
+defaults.set("current", forKey: "liveContainerAutoRefreshExpectedRunID")
+func payload(_ run: String) throws -> Data {
+    try PropertyListSerialization.data(fromPropertyList: ["liveContainerAutoRefreshVerification":
+        ["run_id": run, "results": [["bundle_id": "test.app", "success": true]]]], format: .binary, options: 0)
+}
+let valid = Host()
+valid.finishRefresh(nil, runID: "current", verification: try payload("current"))
+precondition(valid.completions == 1 && valid.lastError == nil)
+precondition(defaults.dictionary(forKey: "liveContainerAutoRefreshVerification")?["run_id"] as? String == "current")
+valid.finishRefresh(nil, runID: "current", verification: try payload("current"))
+precondition(valid.completions == 1)
+let stale = Host()
+stale.finishRefresh(nil, runID: "old", verification: try payload("old"))
+precondition(stale.completions == 0 && stale.c != nil)
+let mismatch = Host()
+mismatch.finishRefresh(nil, runID: "current", verification: try payload("old"))
+precondition(mismatch.completions == 1 && mismatch.lastError != nil)
+for data in [Data([0, 1, 2]), Data(repeating: 0, count: 262145)] {
+    let bad = Host()
+    bad.finishRefresh(nil, runID: "current", verification: data)
+    precondition(bad.completions == 1 && bad.lastError != nil)
+}
+let failed = Host()
+failed.finishRefresh("Signing failed", runID: "current", verification: nil)
+precondition(failed.lastError == "Signing failed")
+print("RESULT_BRIDGE_TESTS_PASSED")
+'''
+        with tempfile.TemporaryDirectory() as directory:
+            file = Path(directory) / "main.swift"
+            executable = Path(directory) / "result-tests"
+            file.write_text(source)
+            subprocess.run([compiler, str(file), "-o", str(executable)], check=True, capture_output=True, text=True)
+            result = subprocess.run([str(executable)], check=True, capture_output=True, text=True)
+            self.assertIn("RESULT_BRIDGE_TESTS_PASSED", result.stdout)
+
+    def test_result_is_correlated_before_import_and_completion(self):
+        self.assertLess(bridge.HOST.index('== runID'), bridge.HOST.index('defaults.set(manifest'))
+        self.assertLess(bridge.HOST.index('defaults.set(manifest'), bridge.HOST.rindex('finish(error)'))
+        self.assertIn('verification.count <= 262144', bridge.HOST)
+        self.assertIn('data.count <= 262144', bridge.CLIENT)
+        self.assertNotIn('dictionaryRepresentation', bridge.CLIENT)
+        for secret in ('password', 'token', 'Keychain', 'certificate'):
+            self.assertNotIn(secret, bridge.CLIENT)
+
+    def test_pinned_xpc_patch_idempotence(self):
+        source = Path(os.environ.get("LIVE_CONTAINER_TEST_SOURCE", ROOT / ".audit/upstream/LiveContainer"))
+        if not source.exists():
+            self.skipTest("Pinned LiveContainer source unavailable")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "SideStoreSupport").mkdir()
+            for name in ('XPCServer.h', 'XPCClient.m', 'SideStore.swift', 'SideStoreClient.swift'):
+                shutil.copy2(source / "SideStoreSupport" / name, root / "SideStoreSupport" / name)
+            host.patch_support(root)
+            bridge.patch(root)
+            first = {p.name: p.read_bytes() for p in (root / "SideStoreSupport").iterdir()}
+            host.patch_support(root)
+            bridge.patch(root)
+            self.assertEqual(first, {p.name: p.read_bytes() for p in (root / "SideStoreSupport").iterdir()})
+            client = (root / "SideStoreSupport/XPCClient.m").read_text()
+            self.assertLess(client.index('setObject:refreshRunID'), client.index('[self performRefreshForRealWithIdentifier:'))
+            self.assertIn('removeObjectForKey:@"liveContainerAutoRefreshVerification"', client)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_refresh_verification_messages.py
+++ b/tests/test_refresh_verification_messages.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import unittest
+
+
+class VerificationMessagesTests(unittest.TestCase):
+    def test_missing_mismatched_and_empty_results_are_distinct(self):
+        source = (Path(__file__).resolve().parents[1] / "scripts/templates/livecontainer_refresh_scheduler.swift").read_text()
+        self.assertNotIn("verification_manifest_missing_or_wrong_run", source)
+        for code in ("manifest_missing", "run_mismatch", "results_empty"):
+            self.assertIn("VERIFICATION_FAILED reason=" + code, source)
+        self.assertIn("Refresh is unconfirmed", source)
+        self.assertIn("different refresh attempt", source)
+        self.assertIn("No successful refresh was confirmed", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -20,6 +20,7 @@ REQUIRED_SCRIPTS = {
 LIVE_CONTAINER_SCRIPT = "patch_livecontainer_autorefresh.py"
 LIVE_CONTAINER_STARTUP_SCRIPT = "patch_embedded_sidestore_startup.py"
 COMBINED_REFRESH_SCRIPT = "patch_combined_refresh_contract.py"
+EMBEDDED_KEYCHAIN_SCRIPT = "patch_embedded_keychain.py"
 
 
 class RepositoryTests(unittest.TestCase):
@@ -33,13 +34,13 @@ class RepositoryTests(unittest.TestCase):
         self.assertEqual(
             {path.name for path in SCRIPTS.glob("*.py")},
             REQUIRED_SCRIPTS | {LIVE_CONTAINER_SCRIPT, LIVE_CONTAINER_STARTUP_SCRIPT,
-                                COMBINED_REFRESH_SCRIPT, 'audit_ipa_signing.py', 'patch_guest_return.py',
+                                COMBINED_REFRESH_SCRIPT, EMBEDDED_KEYCHAIN_SCRIPT, 'audit_ipa_signing.py', 'patch_guest_return.py',
                                 'package_livecontainer_combined.py', 'patch_combined_transport.py'},
         )
 
     def test_patch_scripts_parse_and_are_idempotent(self):
         for name in REQUIRED_SCRIPTS | {LIVE_CONTAINER_SCRIPT, LIVE_CONTAINER_STARTUP_SCRIPT,
-                                        COMBINED_REFRESH_SCRIPT, "patch_combined_transport.py"}:
+                                        COMBINED_REFRESH_SCRIPT, EMBEDDED_KEYCHAIN_SCRIPT, "patch_combined_transport.py"}:
             path = SCRIPTS / name
             ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         self.assertIn(
@@ -64,6 +65,10 @@ class RepositoryTests(unittest.TestCase):
         live_workflow = (ROOT / ".github/workflows/livecontainer-build.yml").read_text(encoding="utf-8")
         self.assertIn("builder/scripts/" + LIVE_CONTAINER_STARTUP_SCRIPT, live_workflow)
         self.assertIn("builder/scripts/" + COMBINED_REFRESH_SCRIPT, live_workflow)
+        contract = (SCRIPTS / COMBINED_REFRESH_SCRIPT).read_text(encoding="utf-8")
+        self.assertIn("from patch_embedded_keychain import patch as patch_shared_keychain", contract)
+        self.assertIn("patch_shared_keychain(Path(sys.argv[1]))", contract)
+        self.assertIn("[LC_KEYCHAIN] SHARED_GROUP_SELECTED", contract)
 
     def test_upstream_ipsec_anchor_preserves_original_punctuation(self):
         source = (SCRIPTS / "patch_sidestore_integration.py").read_text(encoding="utf-8")

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -33,7 +33,7 @@ class RepositoryTests(unittest.TestCase):
         self.assertEqual(
             {path.name for path in SCRIPTS.glob("*.py")},
             REQUIRED_SCRIPTS | {LIVE_CONTAINER_SCRIPT, LIVE_CONTAINER_STARTUP_SCRIPT,
-                                COMBINED_REFRESH_SCRIPT, 'audit_ipa_signing.py',
+                                COMBINED_REFRESH_SCRIPT, 'audit_ipa_signing.py', 'patch_guest_return.py',
                                 'package_livecontainer_combined.py', 'patch_combined_transport.py'},
         )
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -35,12 +35,12 @@ class RepositoryTests(unittest.TestCase):
             {path.name for path in SCRIPTS.glob("*.py")},
             REQUIRED_SCRIPTS | {LIVE_CONTAINER_SCRIPT, LIVE_CONTAINER_STARTUP_SCRIPT,
                                 COMBINED_REFRESH_SCRIPT, EMBEDDED_KEYCHAIN_SCRIPT, 'audit_ipa_signing.py', 'patch_guest_return.py',
-                                'package_livecontainer_combined.py', 'patch_combined_transport.py'},
+                                'package_livecontainer_combined.py', 'patch_combined_transport.py', 'patch_refresh_result_bridge.py'},
         )
 
     def test_patch_scripts_parse_and_are_idempotent(self):
         for name in REQUIRED_SCRIPTS | {LIVE_CONTAINER_SCRIPT, LIVE_CONTAINER_STARTUP_SCRIPT,
-                                        COMBINED_REFRESH_SCRIPT, EMBEDDED_KEYCHAIN_SCRIPT, "patch_combined_transport.py"}:
+                                        COMBINED_REFRESH_SCRIPT, EMBEDDED_KEYCHAIN_SCRIPT, "patch_combined_transport.py", "patch_refresh_result_bridge.py"}:
             path = SCRIPTS / name
             ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         self.assertIn(


### PR DESCRIPTION
## Changes
- Shared embedded authentication, startup/navigation fixes, and Wi-Fi/LocalDevVPN foreground preflight.
- Correlated refresh verification across XPC, reactive status, preserved retry timing, and history improvements.
- Movable/collapsible guest Return control, LiveProcess ownership and resume safety, windowed/fullscreen visibility.
- Stable v2.0.0 release notes, current README, and variant-specific verification/compatibility documentation.

## Verification
Published binary: f20e14e43b4048c5b5791e7d4b0bb6e32930c10a.
CI 34238644076 passed: 76 tests, 2 skipped; both Release builds and combined artifact verification.
Following documentation-only updates: local suite passed, 65 tests with 16 compiler-dependent skips; diff checks passed.
No new IPA build needed for documentation.

## Device limits
Earlier embedded UI/Return interaction and verification-result transfer observed. Final automatic windowed visibility, same-PID resume, complete host replacement, and unattended combined refresh are not claimed proven by CI.
Existing screenshots remain explicitly labeled standalone until replacement images are supplied.