### PR TITLE
Add collapsed startup and custom colors for guest Return controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,13 @@ For deeper investigation, see [Verification](docs/VERIFICATION.md), [Compatibili
 
 Long-press the Return button to collapse it to an edge tab. Tap the tab to restore it. Its position is saved and clamped after resizing.
 
+Source builds after v2.0.1 add these options in **LiveContainer Settings > Guest Controls**:
+
+- **Start Collapsed:** new guests open with an edge tab. Tap once to expand, then tap Return to go back. Using Return collapses the control again, including when reopening a retained guest. The option is off by default.
+- **Use Custom Colors:** choose the **Icon Color** and **Button Background**. The icon color also applies to the collapsed tab; the tab background stays transparent. Turn this option off to restore system colors. Color choices are saved for later use.
+
+These preferences apply to both fullscreen LiveProcess and direct host-process guests. **Show Return Button** still controls visibility, and windowed multitasking still uses the normal window controls.
+
 iOS may still suspend or terminate guest processes because of crashes, memory pressure, or system lifecycle policy.
 
 ## More screenshots

--- a/scripts/patch_guest_return.py
+++ b/scripts/patch_guest_return.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 import sys
 
-MARKER = "LC_GUEST_RETURN_V2"
+MARKER = "LC_GUEST_RETURN_V3"
 
 # Shared by the real control and executable geometry regression tests.
 GEOMETRY = r'''
@@ -19,7 +19,17 @@ static int LCReturnShouldHide(int running, int decorated, int maximized) {
 '''
 
 CONTROL = GEOMETRY + r'''
-// LC_GUEST_RETURN_V2: the control owns no guest process or scene.
+// LC_GUEST_RETURN_V3: the control owns no guest process or scene.
+static UIColor *LCGuestReturnColor(NSString *key, NSUInteger fallbackRGB) {
+    id saved = [NSUserDefaults.lcUserDefaults objectForKey:key];
+    double value = [saved isKindOfClass:NSNumber.class] ? [saved doubleValue] : fallbackRGB;
+    if (!isfinite(value) || value < 0 || value > 0xFFFFFF || floor(value) != value) value = fallbackRGB;
+    NSUInteger rgb = (NSUInteger)value;
+    return [UIColor colorWithRed:((rgb >> 16) & 0xFF) / 255.0
+                           green:((rgb >> 8) & 0xFF) / 255.0
+                            blue:(rgb & 0xFF) / 255.0 alpha:1.0];
+}
+
 @interface LCReturnControl : UIView
 @property(nonatomic, strong) UIButton *button;
 @property(nonatomic, copy) void (^action)(void);
@@ -27,6 +37,7 @@ CONTROL = GEOMETRY + r'''
 @property(nonatomic) CGRect keyboardFrame;
 @property(nonatomic) BOOL collapsed;
 @property(nonatomic, copy) NSString *expandedHint;
+- (void)collapse;
 @end
 @implementation LCReturnControl
 - (instancetype)initWithFrame:(CGRect)frame {
@@ -39,6 +50,7 @@ CONTROL = GEOMETRY + r'''
         double x = [saved[0] doubleValue], y = [saved[1] doubleValue];
         if (isfinite(x) && isfinite(y) && x >= 0 && x <= 1 && y >= 0 && y <= 1) self.position = CGPointMake(x, y);
     }
+    if ([NSUserDefaults.lcUserDefaults boolForKey:@"LCGuestReturnStartsCollapsed"]) [self collapse];
     self.button = [UIButton buttonWithType:UIButtonTypeSystem];
     self.button.backgroundColor = UIColor.secondarySystemBackgroundColor;
     self.button.layer.cornerRadius = 22;
@@ -49,10 +61,7 @@ CONTROL = GEOMETRY + r'''
     __weak typeof(self) weakControl = self;
     self.button.menu = [UIMenu menuWithTitle:@"" children:@[
         [UIAction actionWithTitle:@"Collapse Return Button" image:[UIImage systemImageNamed:@"sidebar.right"] identifier:nil handler:^(__kindof UIAction *action) {
-            weakControl.collapsed = YES;
-            weakControl.position = CGPointMake(weakControl.position.x < 0.5 ? 0 : 1, weakControl.position.y);
-            [weakControl setNeedsLayout];
-            NSLog(@"[LC_RETURN] CONTROL_COLLAPSED");
+            [weakControl collapse];
         }]
     ]];
     [self.button addTarget:self action:@selector(tapped) forControlEvents:UIControlEventTouchUpInside];
@@ -60,10 +69,27 @@ CONTROL = GEOMETRY + r'''
     [self addSubview:self.button];
     [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(keyboard:) name:UIKeyboardWillChangeFrameNotification object:nil];
     [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(keyboard:) name:UIKeyboardWillHideNotification object:nil];
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(preferencesChanged:) name:NSUserDefaultsDidChangeNotification object:NSUserDefaults.lcUserDefaults];
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(preferencesChanged:) name:UIApplicationDidBecomeActiveNotification object:nil];
     NSLog(@"[LC_RETURN] CONTROL_SHOWN");
     return self;
 }
 - (void)dealloc { [NSNotificationCenter.defaultCenter removeObserver:self]; }
+- (void)collapse {
+    self.collapsed = YES;
+    self.position = CGPointMake(self.position.x < 0.5 ? 0 : 1, self.position.y);
+    [self setNeedsLayout];
+    NSLog(@"[LC_RETURN] CONTROL_COLLAPSED");
+}
+- (void)preferencesChanged:(NSNotification *)note {
+    if (!NSThread.isMainThread) {
+        dispatch_async(dispatch_get_main_queue(), ^{ [self preferencesChanged:note]; });
+        return;
+    }
+    // Appearance can change while a guest is retained. Never reset a user's
+    // expanded/collapsed state during layout, keyboard changes, or activation.
+    [self setNeedsLayout];
+}
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
     UIView *hit = [super hitTest:point withEvent:event];
     return hit == self ? nil : hit;
@@ -91,7 +117,11 @@ CONTROL = GEOMETRY + r'''
     if (self.button.hidden) return;
     self.button.accessibilityLabel = self.collapsed ? @"Show Return to LiveContainer" : @"Return to LiveContainer";
     self.button.accessibilityHint = self.collapsed ? @"Restores the Return button" : self.expandedHint;
-    self.button.backgroundColor = self.collapsed ? UIColor.clearColor : UIColor.secondarySystemBackgroundColor;
+    BOOL customColors = [NSUserDefaults.lcUserDefaults boolForKey:@"LCGuestReturnCustomColors"];
+    // nil restores the inherited system tint when custom colors are disabled.
+    self.button.tintColor = customColors ? LCGuestReturnColor(@"LCGuestReturnTintRGB", 0x007AFF) : nil;
+    UIColor *background = customColors ? LCGuestReturnColor(@"LCGuestReturnBackgroundRGB", 0xF2F2F7) : UIColor.secondarySystemBackgroundColor;
+    self.button.backgroundColor = self.collapsed ? UIColor.clearColor : background;
     [self.button setImage:[UIImage systemImageNamed:self.collapsed ? (self.position.x < 0.5 ? @"chevron.compact.right" : @"chevron.compact.left") : @"arrow.uturn.backward.circle.fill"] forState:UIControlStateNormal];
     self.button.bounds = CGRectMake(0, 0, 44, 44);
     self.button.center = CGPointMake(LCReturnAxisCenter(rect.origin.x, rect.size.width, self.position.x),
@@ -127,9 +157,55 @@ CONTROL = GEOMETRY + r'''
         NSLog(@"[LC_RETURN] CONTROL_RESTORED");
         return;
     }
-    if (self.action) self.action();
+    if (self.action) {
+        // A retained guest should reopen as a tab when Start Collapsed is on.
+        if ([NSUserDefaults.lcUserDefaults boolForKey:@"LCGuestReturnStartsCollapsed"]) [self collapse];
+        self.action();
+    }
 }
 @end
+'''
+
+SETTINGS_PROPERTIES = '''    @AppStorage("LCHideReturnControl", store: UserDefaults.lc()) private var hideReturnControl = false
+    @AppStorage("LCGuestReturnStartsCollapsed", store: UserDefaults.lc()) private var returnStartsCollapsed = false
+    @AppStorage("LCGuestReturnCustomColors", store: UserDefaults.lc()) private var returnCustomColors = false
+    @AppStorage("LCGuestReturnTintRGB", store: UserDefaults.lc()) private var returnTintRGB = 0x007AFF
+    @AppStorage("LCGuestReturnBackgroundRGB", store: UserDefaults.lc()) private var returnBackgroundRGB = 0xF2F2F7
+'''
+
+SETTINGS_SECTION = '''                Section {
+                    Toggle("Show Return Button", isOn: Binding(get: { !hideReturnControl }, set: { hideReturnControl = !$0 }))
+                    Group {
+                        Toggle("Start Collapsed", isOn: $returnStartsCollapsed)
+                        Toggle("Use Custom Colors", isOn: $returnCustomColors)
+                        if returnCustomColors {
+                            ColorPicker("Icon Color", selection: returnColorBinding($returnTintRGB), supportsOpacity: false)
+                            ColorPicker("Button Background", selection: returnColorBinding($returnBackgroundRGB), supportsOpacity: false)
+                        }
+                    }
+                    .disabled(hideReturnControl)
+                } header: {
+                    Text("Guest Controls")
+                } footer: {
+                    Text("Start Collapsed shows an edge tab when a guest opens and after using Return. Tap the tab to expand, then tap Return to go back. Long-press Return to collapse it again. Icon Color also applies to the tab; its background stays transparent. Turn off Use Custom Colors to restore system colors.")
+                }'''
+
+SETTINGS_HELPERS = '''    private func returnColorBinding(_ rgb: Binding<Int>) -> Binding<Color> {
+        Binding(get: {
+            let value = rgb.wrappedValue
+            return Color(.sRGB, red: Double((value >> 16) & 0xFF) / 255,
+                         green: Double((value >> 8) & 0xFF) / 255,
+                         blue: Double(value & 0xFF) / 255, opacity: 1)
+        }, set: { color in
+            var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+            guard UIColor(color).getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return }
+            func channel(_ value: CGFloat) -> Int {
+                Int((min(1, max(0, value)) * 255).rounded())
+            }
+            rgb.wrappedValue = (channel(red) << 16) | (channel(green) << 8) | channel(blue)
+        })
+    }
+
 '''
 
 METHODS = r'''
@@ -433,8 +509,9 @@ def verify(texts):
         raise ValueError("Global cross-window callback survived")
     if DIRECT_CONTROL.strip() not in bootstrap or DIRECT_RUNTIME.strip() not in bootstrap:
         raise ValueError("Incomplete direct guest Return patch")
-    if 'Toggle("Show Return Button"' not in settings:
-        raise ValueError("Return visibility setting missing")
+    for block in (SETTINGS_PROPERTIES, SETTINGS_SECTION, SETTINGS_HELPERS):
+        if block.strip() not in settings:
+            raise ValueError("Incomplete guest Return settings: " + block[:65])
     for state in ("YES", "NO"):
         if f"self.isMaximized = {state};\n            [self.appSceneVC.view setNeedsLayout];" not in decorated:
             raise ValueError("Return visibility transition missing: " + state)
@@ -447,8 +524,8 @@ def patch(root):
     if MARKER in implementation:
         verify(texts)
         return
-    if "LC_GUEST_RETURN_V1" in implementation:
-        raise ValueError("Reapply the return patch to clean pinned sources, not a V1-patched tree")
+    if any(marker in implementation for marker in ("LC_GUEST_RETURN_V1", "LC_GUEST_RETURN_V2")):
+        raise ValueError("Reapply the return patch to clean pinned sources, not an older patched tree")
 
     implementation = replace(implementation, '#import "UIKitPrivate+MultitaskSupport.h"',
                              '#import "UIKitPrivate+MultitaskSupport.h"\n#include <math.h>\n' + CONTROL, "control")
@@ -517,11 +594,9 @@ def patch(root):
     tab = replace(tab, "                    DataManager.shared.model.mainWindowOpened = false", "                    DataManager.shared.model.mainWindowOpened = false\n                    if #available(iOS 16.1, *), MultitaskWindowManager.mainSceneSession?.persistentIdentifier == scene1.session.persistentIdentifier {\n                        MultitaskWindowManager.mainSceneSession = nil\n                    }", "clear disconnected main scene")
     bootstrap = replace(bootstrap, "extern char **environ;", "#include <math.h>\n" + DIRECT_CONTROL + DIRECT_RUNTIME + "\nextern char **environ;", "direct return presenter")
     bootstrap = replace(bootstrap, "    // Go!", "    // Install before guest UIApplication/scene creation, never inside LiveProcess.\n    if (!isLiveProcess && !isSideStore) {\n        lcDirectReturnPresenter = [LCDirectReturnPresenter new];\n    }\n    // Go!", "direct launch route")
-    settings = replace(settings, "    @State var errorShow = false", '    @AppStorage("LCHideReturnControl", store: UserDefaults.lc()) private var hideReturnControl = false\n    @State var errorShow = false', "visibility preference")
-    settings = replace(settings, "            Form {", '''            Form {
-                Section("Guest Controls") {
-                    Toggle("Show Return Button", isOn: Binding(get: { !hideReturnControl }, set: { hideReturnControl = !$0 }))
-                }''', "restore return control")
+    settings = replace(settings, "    @State var errorShow = false", SETTINGS_PROPERTIES + "    @State var errorShow = false", "Return preferences")
+    settings = replace(settings, "    var body: some View {", SETTINGS_HELPERS + "    var body: some View {", "Return color bindings")
+    settings = replace(settings, "            Form {", "            Form {\n" + SETTINGS_SECTION, "Return settings")
     for state in ("YES", "NO"):
         decorated = replace(decorated, f"self.isMaximized = {state};",
                             f"self.isMaximized = {state};\n            [self.appSceneVC.view setNeedsLayout];",

--- a/tests/fixtures/guest_return_control_harness.m
+++ b/tests/fixtures/guest_return_control_harness.m
@@ -1,0 +1,113 @@
+// Execute the injected actions and color decoder with Foundation on macOS.
+// This checks state transitions and persistence, not UIKit rendering or gestures.
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+
+static NSUserDefaults *preferences;
+@interface NSUserDefaults (ReturnTests)
++ (instancetype)lcUserDefaults;
+@end
+@implementation NSUserDefaults (ReturnTests)
++ (instancetype)lcUserDefaults { return preferences; }
+@end
+
+@interface UIColor : NSObject
+@property double red;
+@property double green;
+@property double blue;
+@property double alpha;
++ (instancetype)colorWithRed:(double)red green:(double)green blue:(double)blue alpha:(double)alpha;
+@end
+@implementation UIColor
++ (instancetype)colorWithRed:(double)red green:(double)green blue:(double)blue alpha:(double)alpha {
+    UIColor *color = [UIColor new];
+    color.red = red; color.green = green; color.blue = blue; color.alpha = alpha;
+    return color;
+}
+@end
+
+// COLOR_DECODER
+
+@interface TestControl : NSObject
+@property BOOL collapsed;
+@property CGPoint position;
+@property NSUInteger layoutRequests;
+@property(copy) void (^action)(void);
+- (void)setNeedsLayout;
+- (void)collapse;
+- (void)tapped;
+@end
+@implementation TestControl
+- (void)setNeedsLayout { self.layoutRequests += 1; }
+// COLLAPSE_METHOD
+// TAPPED_METHOD
+@end
+
+static void assertColor(UIColor *color, NSUInteger expected) {
+    assert(fabs(color.red - ((expected >> 16) & 0xFF) / 255.0) < 0.000001);
+    assert(fabs(color.green - ((expected >> 8) & 0xFF) / 255.0) < 0.000001);
+    assert(fabs(color.blue - (expected & 0xFF) / 255.0) < 0.000001);
+    assert(color.alpha == 1);
+}
+
+int main(void) {
+    @autoreleasepool {
+        NSString *suite = [@"GuestReturnTests." stringByAppendingString:NSProcessInfo.processInfo.globallyUniqueString];
+        preferences = [[NSUserDefaults alloc] initWithSuiteName:suite];
+        @try {
+            NSString *colorKey = @"LCGuestReturnTintRGB";
+            assertColor(LCGuestReturnColor(colorKey, 0x007AFF), 0x007AFF);
+            for (NSNumber *rgb in @[@0, @0xFFFFFF, @0x123456, @0xFF0000, @0x00FF00, @0x0000FF]) {
+                [preferences setObject:rgb forKey:colorKey];
+                assertColor(LCGuestReturnColor(colorKey, 0x007AFF), rgb.unsignedIntegerValue);
+            }
+            // Corrupt and older preference data must yield a visible default.
+            for (id invalid in @[@"red", @[], @{}, @(-1), @0x1000000, @1.5, @(NAN), @(INFINITY)]) {
+                [preferences setObject:invalid forKey:colorKey];
+                assertColor(LCGuestReturnColor(colorKey, 0x007AFF), 0x007AFF);
+            }
+            [preferences removeObjectForKey:colorKey];
+            assertColor(LCGuestReturnColor(colorKey, 0xF2F2F7), 0xF2F2F7);
+
+            __block NSUInteger actions = 0;
+            TestControl *control = [TestControl new];
+            control.action = ^{ actions += 1; };
+            control.position = CGPointMake(0.2, 0.7);
+            [control collapse];
+            assert(control.collapsed && control.position.x == 0 && control.position.y == 0.7);
+            [control tapped];
+            assert(!control.collapsed && actions == 0); // Expansion must never Return.
+            [control tapped];
+            assert(!control.collapsed && actions == 1); // Default remains expanded.
+            assert([preferences objectForKey:@"LCHideReturnControl"] == nil);
+            assert([preferences objectForKey:@"LCGuestReturnStartsCollapsed"] == nil);
+
+            [preferences setBool:YES forKey:@"LCGuestReturnStartsCollapsed"];
+            control.position = CGPointMake(0.8, 0.3);
+            [control collapse];
+            assert(control.position.x == 1 && control.position.y == 0.3);
+            for (int reopen = 0; reopen < 3; reopen++) {
+                NSUInteger before = actions;
+                [control tapped];
+                assert(!control.collapsed && actions == before);
+                [control tapped];
+                assert(control.collapsed && actions == before + 1);
+                assert(control.position.x == 1 && control.position.y == 0.3);
+            }
+            assert([preferences boolForKey:@"LCGuestReturnStartsCollapsed"]);
+            assert([preferences objectForKey:@"LCHideReturnControl"] == nil);
+            [preferences setBool:NO forKey:@"LCGuestReturnStartsCollapsed"];
+            [control tapped];
+            [control tapped];
+            assert(!control.collapsed);
+            assert(control.layoutRequests > 0);
+            puts("RETURN_CONTROL_TESTS_PASSED");
+        } @finally {
+            [preferences removePersistentDomainForName:suite];
+        }
+    }
+    return 0;
+}

--- a/tests/test_guest_return.py
+++ b/tests/test_guest_return.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -184,12 +185,61 @@ class GuestReturnTests(unittest.TestCase):
     def test_collapse_does_not_disable_global_preference_or_return(self):
         for control in (module.CONTROL, module.DIRECT_CONTROL):
             self.assertNotIn('setBool:YES forKey:@"LCHideReturnControl"', control)
-            self.assertIn('weakControl.collapsed = YES', control)
+            self.assertIn('[weakControl collapse]', control)
+            self.assertIn('self.collapsed = YES', control)
             self.assertIn('self.collapsed = NO', control)
             self.assertIn('CONTROL_RESTORED', control)
             self.assertIn('chevron.compact.right', control)
             tapped = control[control.index('- (void)tapped'):]
             self.assertLess(tapped.index('return;'), tapped.index('self.action()'))
+
+    def test_start_collapsed_is_shared_and_does_not_reset_on_layout(self):
+        for control in (module.CONTROL, module.DIRECT_CONTROL):
+            init = control[control.index('- (instancetype)initWithFrame:'):control.index('- (void)dealloc')]
+            self.assertIn('boolForKey:@"LCGuestReturnStartsCollapsed"]) [self collapse]', init)
+            self.assertLess(init.index('isfinite(x)'), init.index('[self collapse]'))
+            for start, end in (('- (void)layoutSubviews', '- (void)keyboard:'),
+                               ('- (void)preferencesChanged:', '- (UIView *)hitTest:')):
+                self.assertNotIn('[self collapse]', control[control.index(start):control.index(end)])
+            self.assertIn('name:NSUserDefaultsDidChangeNotification object:NSUserDefaults.lcUserDefaults', control)
+            self.assertIn('name:UIApplicationDidBecomeActiveNotification', control)
+        self.assertIn('private var returnStartsCollapsed = false', module.SETTINGS_PROPERTIES)
+        self.assertIn('private var returnCustomColors = false', module.SETTINGS_PROPERTIES)
+        for key in ('LCGuestReturnStartsCollapsed', 'LCGuestReturnCustomColors',
+                    'LCGuestReturnTintRGB', 'LCGuestReturnBackgroundRGB'):
+            self.assertIn(f'@AppStorage("{key}", store: UserDefaults.lc())', module.SETTINGS_PROPERTIES)
+            self.assertIn(f'@"{key}"', module.CONTROL)
+            self.assertIn(f'@"{key}"', module.DIRECT_CONTROL)
+
+    def test_appearance_keeps_tab_transparent_and_system_colors_available(self):
+        for control in (module.CONTROL, module.DIRECT_CONTROL):
+            layout = control[control.index('- (void)layoutSubviews'):control.index('- (void)keyboard:')]
+            self.assertIn('self.collapsed ? UIColor.clearColor : background', layout)
+            self.assertIn('LCGuestReturnColor(@"LCGuestReturnTintRGB", 0x007AFF) : nil', layout)
+            self.assertIn('LCGuestReturnColor(@"LCGuestReturnBackgroundRGB", 0xF2F2F7) : UIColor.secondarySystemBackgroundColor', layout)
+        self.assertIn('private var returnTintRGB = 0x007AFF', module.SETTINGS_PROPERTIES)
+        self.assertIn('private var returnBackgroundRGB = 0xF2F2F7', module.SETTINGS_PROPERTIES)
+
+    def test_control_actions_and_color_decoding_execute(self):
+        compiler = shutil.which('clang')
+        if sys.platform != 'darwin' or not compiler:
+            self.skipTest('Objective-C Foundation runtime requires macOS')
+        harness = (ROOT / 'tests/fixtures/guest_return_control_harness.m').read_text()
+        color = module.CONTROL.split('static UIColor *LCGuestReturnColor', 1)[1].split('@interface LCReturnControl', 1)[0]
+        collapse = module.CONTROL.split('- (void)collapse {', 1)[1].split('- (void)preferencesChanged:', 1)[0]
+        tapped = module.CONTROL.split('- (void)tapped {', 1)[1].split('@end', 1)[0]
+        source = harness.replace('// COLOR_DECODER', 'static UIColor *LCGuestReturnColor' + color)
+        source = source.replace('// COLLAPSE_METHOD', '- (void)collapse {' + collapse)
+        source = source.replace('// TAPPED_METHOD', '- (void)tapped {' + tapped)
+        with tempfile.TemporaryDirectory() as directory:
+            src, exe = Path(directory)/'Control.m', Path(directory)/'control'
+            src.write_text(source)
+            build = subprocess.run([compiler, '-fobjc-arc', '-fblocks', '-framework', 'Foundation',
+                                    str(src), '-o', str(exe)], capture_output=True, text=True)
+            self.assertEqual(build.returncode, 0, build.stderr)
+            run = subprocess.run([str(exe)], capture_output=True, text=True)
+            self.assertEqual(run.returncode, 0, run.stderr)
+            self.assertIn('RETURN_CONTROL_TESTS_PASSED', run.stdout)
 
     def test_cleanup_finishes_before_exit_callback(self):
         self.assertLess(module.CLEANUP.index("unregisterMultitaskContainer"), module.CLEANUP.index("appSceneVCAppDidExit"))
@@ -270,6 +320,15 @@ int main(void) {
             first = {name: (root/name).read_bytes() for name in module.PATHS}
             module.patch(root)
             self.assertEqual(first, {name: (root/name).read_bytes() for name in module.PATHS})
+            # An already patched tree must not silently accept stale settings.
+            settings_path = root / 'LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift'
+            settings_bytes = settings_path.read_bytes()
+            settings_path.write_text(settings_path.read_text().replace('LCGuestReturnTintRGB', 'WrongTintKey'))
+            before = {name: (root/name).read_bytes() for name in module.PATHS}
+            with self.assertRaisesRegex(ValueError, 'guest Return settings'):
+                module.patch(root)
+            self.assertEqual(before, {name: (root/name).read_bytes() for name in module.PATHS})
+            settings_path.write_bytes(settings_bytes)
             compiler = shutil.which("swiftc")
             if compiler:
                 for name in module.PATHS:


### PR DESCRIPTION
Guest Return controls currently open expanded and always use system colors. Add **Start Collapsed** and **Use Custom Colors** under LiveContainer Settings > Guest Controls, including separate icon and background color pickers. Both options default off and use the host preferences shared by fullscreen LiveProcess and direct guests.

With Start Collapsed enabled, tapping the tab expands it without returning; tapping Return collapses it again before the existing host action so retained guests reopen as a tab. The tab keeps a transparent background and uses the chosen icon color. Disabling custom colors restores system colors while preserving saved choices. Existing visibility, windowed-mode hiding, dragging, and guest lifecycle behavior remain intact.

Validation at commit `5103c7a5ee428f7605b857f4fa600a561135ba93`:
- [Build 34444064792 passed](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/runs/34444064792): 79 repository tests, 2 skipped; both iOS Release builds; transport checks; combined IPA packaging and runtime verification.
- New executable Objective-C tests passed for two-tap Return behavior, repeated retained-guest returns, edge placement, and valid/missing/corrupt saved colors. Pinned-source tests also verify patch idempotence and rejection of mismatched settings.
- Isolated Windows checkout: 68 tests, 20 skipped for unavailable toolchains/fixtures, no failures. `git diff --check` passed.
- Downloaded IPA inspection confirmed all four new preference keys in both `LiveContainerShared` and `LiveContainerSwiftUI`, plus the new settings labels in `LiveContainerSwiftUI`.
- The unsigned combined IPA is available in the run's `LiveContainer-SideStore-AutoRefresh-IPA` artifact. SHA-256: `44981d3e0f1204f3a9ecaab7b608a470a7a963e3be0175748cf7115f62501784`.

Device installation passed on an iPhone 12 running iOS 26.6.1: iLoader signed and installed this artifact over the existing host, and the updated app launched successfully. A local build of iLoader with nab138/isideload#11 was required to resolve its unrelated GrandSlam HTTP 503 login error on the same PC/network.

Device UI validation remains pending: check both guest modes, saved colors after relaunch, tab expansion, drag/rotation/keyboard handling, system-color restoration, and windowed visibility.

Closes #14.