### PR TITLE
Release standalone v1.0.3 with SideStore 0.7 and updated documentation

### DIFF
--- a/.github/workflows/build-current.yml
+++ b/.github/workflows/build-current.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  SIDESTORE_REF: 394bb4eb331cb4afc23517af2fc847ec103af57f
-  MINIMUXER_REF: e0de126ec6773c02afe7d965def86ddffd79cbeb
+  SIDESTORE_REF: c6f28864dc99ed03ad35f2ca58967247036b7b53
+  MINIMUXER_REF: 9f038e5223a8cacf9d15beae7da6969d617ae1e8
   IDEVICE_REF: ebd7dadfc55d1c4facee3d11ecf5b28e20548b57
   JKTCP_REF: e674e1eee6d5943e13b1eba0bd24a9dd0b2fa020
 
@@ -70,6 +70,8 @@ jobs:
       - name: Run repository checks
         env:
           SIDESTORE_TEST_SOURCE: ${{ github.workspace }}/work/SideStore
+          SIDESTORE_070_TEST_SOURCE: ${{ github.workspace }}/work/SideStore
+          REQUIRE_SWIFT_070_CHECKS: '1'
         run: |
           set -euo pipefail
           python3 -m unittest discover -s builder/tests -v
@@ -141,8 +143,6 @@ jobs:
           grep -Fq 'tunnel_create_usb' ffi/idevice.h
           grep -Fq 'tunnel_heartbeat_is_active' ffi/idevice.h
           grep -Fq 'idevice_set_transport_log_callback' ffi/idevice.h
-          # Apple nm cannot read LLVM metadata in some Rust compiler_builtins
-          # members, but it still emits symbols from the FFI members we need.
           xcrun nm -arch arm64 -g target/aarch64-apple-ios/release/libidevice_ffi.a \
             >/tmp/current-idevice-symbols.txt 2>/tmp/current-nm-reader-warnings.txt || true
           grep -E '[[:space:]][Tt][[:space:]]_lockdown_diag_rust_log$' \
@@ -165,6 +165,8 @@ jobs:
           rm -rf "$MUX/DeviceGateway/LocalBinary/IDevice.xcframework"
           cp -R idevice/swift/IDevice.xcframework "$MUX/DeviceGateway/LocalBinary/IDevice.xcframework"
 
+          python3 builder/scripts/adapt_sidestore_070_pairing.py "$MUX"
+          python3 builder/scripts/adapt_sidestore_070_signing.py "$SIDE"
           python3 builder/scripts/patch_sidestore_integration.py "$MUX" "$SIDE"
           python3 builder/scripts/patch_background_automation.py "$SIDE"
           python3 builder/scripts/patch_local_idevice_package.py "$MUX"
@@ -195,44 +197,9 @@ jobs:
           grep -Fq '[SIDESTORE_COREDEVICE] ENDPOINT_SELECT' "$NETWORK_OBSERVER"
           grep -Fq '[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED' "$MINIMUXER_IMPL"
           ! grep -Fq 'no ipsec interface (required for lockdown on iOS 26.4+)' "$MINIMUXER_IMPL"
-          python3 - "$PAIRING_PROTOCOL" <<'PY'
-          from pathlib import Path
-          import sys
-
-          text = Path(sys.argv[1]).read_text(encoding="utf-8")
-          lockdown = text.index('let requiredLockdownKeys = [')
-          remote_pairing = text.index('let requiredRPKeys = [')
-          assert lockdown < remote_pairing, "composite pairing records do not prefer Lockdown"
-          PY
-          cat >/tmp/main.swift <<'SWIFT'
-          import Foundation
-
-          let lockdownKeys = [
-              "WiFiMACAddress", "SystemBUID", "RootPrivateKey", "HostPrivateKey",
-              "HostID", "RootCertificate", "UDID", "EscrowBag",
-              "HostCertificate", "DeviceCertificate",
-          ]
-          let remotePairingKeys = ["private_key", "public_key", "identifier"]
-
-          func record(_ keys: [String]) -> [String: any Sendable] {
-              var result: [String: any Sendable] = [:]
-              for key in keys {
-                  result[key] = "present"
-              }
-              return result
-          }
-
-          let lockdownMode = try PairingProtocol.validatePairingFile(from: record(lockdownKeys))
-          let remotePairingMode = try PairingProtocol.validatePairingFile(from: record(remotePairingKeys))
-          let compositeMode = try PairingProtocol.validatePairingFile(
-              from: record(lockdownKeys + remotePairingKeys)
-          )
-          precondition(lockdownMode == .lockdown)
-          precondition(remotePairingMode == .rppairing)
-          precondition(compositeMode == .lockdown)
-          print("pairing protocol selection tests passed")
-          SWIFT
-          swiftc "$PAIRING_PROTOCOL" /tmp/main.swift -o /tmp/current-pairing-selection-test
+          swiftc "$MUX/Common/MinimuxerConstants.swift" "$PAIRING_PROTOCOL" \
+            "$MUX/Common/PairingFile.swift" builder/tests/standalone_pairing_policy.swift \
+            -o /tmp/current-pairing-selection-test
           /tmp/current-pairing-selection-test
           grep -Fq 'CoreDevice heartbeat is maintained by Rust; poll its state without spinning.' \
             "$MUX/Sources/Services/HeartbeatService.swift"

--- a/.github/workflows/build-publish-v1.0.3-r2.yml
+++ b/.github/workflows/build-publish-v1.0.3-r2.yml
@@ -1,0 +1,255 @@
+name: Build and publish standalone v1.0.3 r2
+
+on:
+  push:
+    branches: [release/v1.0.3]
+    paths:
+      - '.github/workflows/build-publish-v1.0.3-r2.yml'
+
+permissions:
+  contents: write
+
+env:
+  SIDESTORE_REF: c6f28864dc99ed03ad35f2ca58967247036b7b53
+  MINIMUXER_REF: 9f038e5223a8cacf9d15beae7da6969d617ae1e8
+  IDEVICE_REF: ebd7dadfc55d1c4facee3d11ecf5b28e20548b57
+  JKTCP_REF: e674e1eee6d5943e13b1eba0bd24a9dd0b2fa020
+
+jobs:
+  build-and-publish:
+    runs-on: macos-26
+    timeout-minutes: 75
+    steps:
+      - name: Checkout builder
+        uses: actions/checkout@v4
+        with:
+          path: builder
+          fetch-depth: 1
+
+      - name: Checkout SideStore 0.7.0 nightly
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/SideStore
+          ref: ${{ env.SIDESTORE_REF }}
+          path: work/SideStore
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Checkout idevice
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/idevice
+          ref: ${{ env.IDEVICE_REF }}
+          path: idevice
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Checkout jktcp
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/jktcp
+          ref: ${{ env.JKTCP_REF }}
+          path: jktcp
+          fetch-depth: 1
+
+      - name: Verify exact source revisions
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git -C work/SideStore rev-parse HEAD)" = "$SIDESTORE_REF"
+          test "$(git -C work/SideStore/Dependencies/minimuxer rev-parse HEAD)" = "$MINIMUXER_REF"
+          test "$(git -C idevice rev-parse HEAD)" = "$IDEVICE_REF"
+          test "$(git -C jktcp rev-parse HEAD)" = "$JKTCP_REF"
+          python3 -m py_compile \
+            builder/scripts/patch_jktcp_reliability.py \
+            builder/scripts/patch_coredevice_idevice.py \
+            builder/scripts/patch_sidestore_integration.py \
+            builder/scripts/patch_background_automation.py \
+            builder/scripts/patch_local_idevice_package.py
+
+      - name: Run source-independent repository checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover -s builder/tests -v
+
+      - name: Select Xcode 26.4
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: '26.4'
+
+      - name: Install build tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v ldid >/dev/null 2>&1; then HOMEBREW_NO_AUTO_UPDATE=1 brew install ldid; fi
+          if ! command -v bindgen >/dev/null 2>&1; then cargo install --locked bindgen-cli --version 0.72.1; fi
+          rustup target add aarch64-apple-ios
+
+      - name: Patch and test CoreDevice transport
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 builder/scripts/patch_jktcp_reliability.py jktcp
+          python3 builder/scripts/patch_coredevice_idevice.py idevice jktcp
+          cargo fmt --manifest-path jktcp/Cargo.toml
+          cargo fmt --manifest-path idevice/ffi/Cargo.toml
+          git -C jktcp diff --check
+          git -C idevice diff --check
+          cargo test --manifest-path jktcp/Cargo.toml --lib -- --skip tests::local_tcp --skip tests::handle_speed
+          cargo check --manifest-path idevice/ffi/Cargo.toml --features obfuscate
+
+      - name: Build idevice for iOS
+        shell: bash
+        working-directory: idevice
+        run: |
+          set -euo pipefail
+          BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$(xcrun --sdk iphoneos --show-sdk-path)" \
+            IPHONEOS_DEPLOYMENT_TARGET=15.0 \
+            cargo build --release --target aarch64-apple-ios --features obfuscate --manifest-path ffi/Cargo.toml
+          test -f target/aarch64-apple-ios/release/libidevice_ffi.a
+          rm -rf swift/IDevice.xcframework
+          cp ffi/idevice.h swift/include/idevice.h
+          xcodebuild -create-xcframework \
+            -library target/aarch64-apple-ios/release/libidevice_ffi.a \
+            -headers swift/include \
+            -output swift/IDevice.xcframework
+
+      - name: Patch SideStore and verify patches against 0.7.0
+        shell: bash
+        run: |
+          set -euo pipefail
+          SIDE=work/SideStore
+          MUX="$SIDE/Dependencies/minimuxer"
+          mkdir -p "$MUX/DeviceGateway/LocalBinary"
+          rm -rf "$MUX/DeviceGateway/LocalBinary/IDevice.xcframework"
+          cp -R idevice/swift/IDevice.xcframework "$MUX/DeviceGateway/LocalBinary/IDevice.xcframework"
+          python3 builder/scripts/patch_sidestore_integration.py "$MUX" "$SIDE"
+          python3 builder/scripts/patch_background_automation.py "$SIDE"
+          python3 builder/scripts/patch_local_idevice_package.py "$MUX"
+          git -C "$MUX" diff --check
+          swiftc -frontend -parse "$MUX/DeviceGateway/idevice/IdeviceGateway.swift"
+          swiftc -frontend -parse "$MUX/Common/PairingProtocol.swift"
+          swiftc -frontend -parse "$MUX/Sources/Services/NetworkObserverService.swift"
+          swiftc -frontend -parse "$MUX/Sources/MinimuxerImpl.swift"
+          swiftc -frontend -parse "$SIDE/SideStore/Core/Operations/PipelineOperations/ResignAppOperation.swift"
+          swiftc -frontend -parse "$SIDE/SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/AppDelegate.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/SceneDelegate.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/Settings/SettingsViewController.swift"
+          grep -Fq '[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED' "$MUX/DeviceGateway/idevice/IdeviceGateway.swift"
+          grep -Fq '[SIDESTORE_COREDEVICE] ENDPOINT_SELECT' "$MUX/Sources/Services/NetworkObserverService.swift"
+          grep -Fq '[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED' "$MUX/Sources/MinimuxerImpl.swift"
+          grep -Fq '[AUTO_REFRESH] AUTH_PREFLIGHT_PASS' "$SIDE/SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift"
+
+      - name: Resolve Swift packages
+        shell: bash
+        working-directory: work/SideStore
+        run: |
+          set -euo pipefail
+          ok=0
+          for attempt in 1 2 3; do
+            if xcodebuild -resolvePackageDependencies -disablePackageRepositoryCache -project AltStore.xcodeproj -scheme SideStore; then
+              ok=1
+              break
+            fi
+            sleep 2
+          done
+          test "$ok" -eq 1
+
+      - name: Build standalone SideStore IPA
+        shell: bash
+        working-directory: work/SideStore
+        run: |
+          set -euo pipefail
+          mkdir -p build/logs
+          plutil -replace CFBundleDisplayName -string SideStore AltStore/Info.plist || plutil -insert CFBundleDisplayName -string SideStore AltStore/Info.plist
+          NSUnbufferedIO=YES make -B build 2>&1 | tee build/logs/build.log
+          make fakesign 2>&1 | tee -a build/logs/build.log
+          make ipa 2>&1 | tee -a build/logs/build.log
+          test -f SideStore.ipa
+
+      - name: Verify release IPA
+        shell: bash
+        run: |
+          set -euo pipefail
+          IPA=work/SideStore/SideStore.ipa
+          unzip -t "$IPA" >/tmp/v103-unzip.txt
+          rm -rf /tmp/v103-ipa
+          mkdir -p /tmp/v103-ipa
+          unzip -q "$IPA" -d /tmp/v103-ipa
+          find /tmp/v103-ipa/Payload/SideStore.app -type f -size +32k -print0 | xargs -0 strings >/tmp/v103-strings.txt
+          for marker in \
+            '[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED' \
+            '[SIDESTORE_COREDEVICE] TRANSPORT_CREATE_PASS' \
+            '[SIDESTORE_COREDEVICE] ENDPOINT_SELECT' \
+            '[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED' \
+            '[SELF_REFRESH] SELF_REFRESH_COMPLETE' \
+            '[AUTO_REFRESH] REGISTER_PASS' \
+            '[AUTO_REFRESH] COMPLETE' \
+            '[AUTO_REFRESH] AUTH_PREFLIGHT_PASS'; do
+            grep -Fq "$marker" /tmp/v103-strings.txt
+          done
+          cp "$IPA" SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa
+          shasum -a 256 SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa | awk '{print $1 "  SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa"}' > SHA256SUMS.txt
+          cat > RELEASE_NOTES_v1.0.3.md <<EOF
+          # SideStore CoreDevice Auto-Refresh v1.0.3
+
+          Standalone SideStore update based on SideStore 0.7.0 nightly.
+
+          ## What's new
+
+          - Updated upstream SideStore to \`c6f28864dc99ed03ad35f2ca58967247036b7b53\` (0.7.0 nightly, 2026-09-11).
+          - Includes the newer SideStore/SideSign authentication path with the upstream GSA 5XX mitigation.
+          - Retains this project's LocalDevVPN + CoreDevice same-device transport patches.
+          - Retains manual refresh, six-hour/daily/weekly scheduling, refresh history, verification, retry handling, and diagnostics.
+
+          ## Installation
+
+          Sign the IPA with your Apple Account using a compatible installer and install it over the existing matching standalone SideStore installation.
+
+          Do not delete SideStore first if you want to preserve existing app data and setup.
+
+          ## Provenance
+
+          - Builder commit: \`$GITHUB_SHA\`
+          - SideStore upstream: \`$SIDESTORE_REF\`
+          - minimuxer upstream: \`$MINIMUXER_REF\`
+          - idevice: \`$IDEVICE_REF\`
+          - jktcp: \`$JKTCP_REF\`
+
+          Cellular-only refresh remains experimental and is not part of this stable release.
+          EOF
+
+      - name: Publish v1.0.3
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view v1.0.3 --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo 'Release v1.0.3 already exists; refusing to overwrite.'
+            exit 1
+          fi
+          gh release create v1.0.3 \
+            SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa \
+            SHA256SUMS.txt \
+            RELEASE_NOTES_v1.0.3.md \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title 'SideStore CoreDevice Auto-Refresh v1.0.3' \
+            --notes-file RELEASE_NOTES_v1.0.3.md
+
+      - name: Upload build evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: SideStore-v1.0.3-r2-build-evidence
+          path: |
+            work/SideStore/build/logs
+            /tmp/v103-unzip.txt
+            /tmp/v103-strings.txt
+            SHA256SUMS.txt
+            RELEASE_NOTES_v1.0.3.md
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/build-publish-v1.0.3-r3.yml
+++ b/.github/workflows/build-publish-v1.0.3-r3.yml
@@ -1,0 +1,256 @@
+name: Build and publish standalone v1.0.3 r3
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  SIDESTORE_REF: c6f28864dc99ed03ad35f2ca58967247036b7b53
+  MINIMUXER_REF: 9f038e5223a8cacf9d15beae7da6969d617ae1e8
+  IDEVICE_REF: ebd7dadfc55d1c4facee3d11ecf5b28e20548b57
+  JKTCP_REF: e674e1eee6d5943e13b1eba0bd24a9dd0b2fa020
+
+jobs:
+  build-and-publish:
+    runs-on: macos-26
+    timeout-minutes: 75
+    steps:
+      - name: Checkout builder
+        uses: actions/checkout@v4
+        with:
+          path: builder
+          fetch-depth: 1
+
+      - name: Checkout SideStore 0.7.0 nightly
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/SideStore
+          ref: ${{ env.SIDESTORE_REF }}
+          path: work/SideStore
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Checkout idevice
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/idevice
+          ref: ${{ env.IDEVICE_REF }}
+          path: idevice
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Checkout jktcp
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/jktcp
+          ref: ${{ env.JKTCP_REF }}
+          path: jktcp
+          fetch-depth: 1
+
+      - name: Verify exact source revisions
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git -C work/SideStore rev-parse HEAD)" = "$SIDESTORE_REF"
+          test "$(git -C work/SideStore/Dependencies/minimuxer rev-parse HEAD)" = "$MINIMUXER_REF"
+          test "$(git -C idevice rev-parse HEAD)" = "$IDEVICE_REF"
+          test "$(git -C jktcp rev-parse HEAD)" = "$JKTCP_REF"
+          python3 -m py_compile \
+            builder/scripts/patch_jktcp_reliability.py \
+            builder/scripts/patch_coredevice_idevice.py \
+            builder/scripts/patch_sidestore_integration.py \
+            builder/scripts/patch_background_automation.py \
+            builder/scripts/patch_local_idevice_package.py
+
+      - name: Run source-independent repository checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover -s builder/tests -v
+
+      - name: Select Xcode 26.4
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: '26.4'
+
+      - name: Install build tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v ldid >/dev/null 2>&1; then HOMEBREW_NO_AUTO_UPDATE=1 brew install ldid; fi
+          if ! command -v bindgen >/dev/null 2>&1; then cargo install --locked bindgen-cli --version 0.72.1; fi
+          rustup target add aarch64-apple-ios
+
+      - name: Patch and test CoreDevice transport
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 builder/scripts/patch_jktcp_reliability.py jktcp
+          python3 builder/scripts/patch_coredevice_idevice.py idevice jktcp
+          cargo fmt --manifest-path jktcp/Cargo.toml
+          cargo fmt --manifest-path idevice/ffi/Cargo.toml
+          git -C jktcp diff --check
+          git -C idevice diff --check
+          cargo test --manifest-path jktcp/Cargo.toml --lib -- --skip tests::local_tcp --skip tests::handle_speed
+          cargo check --manifest-path idevice/ffi/Cargo.toml --features obfuscate
+
+      - name: Build idevice for iOS
+        shell: bash
+        working-directory: idevice
+        run: |
+          set -euo pipefail
+          BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$(xcrun --sdk iphoneos --show-sdk-path)" \
+            IPHONEOS_DEPLOYMENT_TARGET=15.0 \
+            cargo build --release --target aarch64-apple-ios --features obfuscate --manifest-path ffi/Cargo.toml
+          test -f target/aarch64-apple-ios/release/libidevice_ffi.a
+          rm -rf swift/IDevice.xcframework
+          cp ffi/idevice.h swift/include/idevice.h
+          xcodebuild -create-xcframework \
+            -library target/aarch64-apple-ios/release/libidevice_ffi.a \
+            -headers swift/include \
+            -output swift/IDevice.xcframework
+
+      - name: Patch SideStore and verify patches against 0.7.0
+        shell: bash
+        run: |
+          set -euo pipefail
+          SIDE=work/SideStore
+          MUX="$SIDE/Dependencies/minimuxer"
+          mkdir -p "$MUX/DeviceGateway/LocalBinary"
+          rm -rf "$MUX/DeviceGateway/LocalBinary/IDevice.xcframework"
+          cp -R idevice/swift/IDevice.xcframework "$MUX/DeviceGateway/LocalBinary/IDevice.xcframework"
+          python3 builder/scripts/adapt_sidestore_070_pairing.py "$MUX"
+          python3 builder/scripts/adapt_sidestore_070_signing.py "$SIDE"
+          python3 builder/scripts/patch_sidestore_integration.py "$MUX" "$SIDE"
+          python3 builder/scripts/patch_background_automation.py "$SIDE"
+          python3 builder/scripts/patch_local_idevice_package.py "$MUX"
+          git -C "$MUX" diff --check
+          swiftc -frontend -parse "$MUX/DeviceGateway/idevice/IdeviceGateway.swift"
+          swiftc -frontend -parse "$MUX/Common/PairingProtocol.swift"
+          swiftc -frontend -parse "$MUX/Common/PairingFile.swift"
+          swiftc -frontend -parse "$MUX/Sources/Services/NetworkObserverService.swift"
+          swiftc -frontend -parse "$MUX/Sources/MinimuxerImpl.swift"
+          swiftc -frontend -parse "$SIDE/SideStore/Core/Operations/PipelineOperations/ResignAppOperation.swift"
+          swiftc -frontend -parse "$SIDE/SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/AppDelegate.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/SceneDelegate.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/Settings/SettingsViewController.swift"
+          grep -Fq 'Composite records must use Lockdown/CoreDevice' "$MUX/Common/PairingFile.swift"
+          grep -Fq '[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED' "$MUX/DeviceGateway/idevice/IdeviceGateway.swift"
+          grep -Fq '[SIDESTORE_COREDEVICE] ENDPOINT_SELECT' "$MUX/Sources/Services/NetworkObserverService.swift"
+          grep -Fq '[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED' "$MUX/Sources/MinimuxerImpl.swift"
+          grep -Fq '[AUTO_REFRESH] AUTH_PREFLIGHT_PASS' "$SIDE/SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift"
+
+      - name: Resolve Swift packages
+        shell: bash
+        working-directory: work/SideStore
+        run: |
+          set -euo pipefail
+          ok=0
+          for attempt in 1 2 3; do
+            if xcodebuild -resolvePackageDependencies -disablePackageRepositoryCache -project AltStore.xcodeproj -scheme SideStore; then
+              ok=1
+              break
+            fi
+            sleep 2
+          done
+          test "$ok" -eq 1
+
+      - name: Build standalone SideStore IPA
+        shell: bash
+        working-directory: work/SideStore
+        run: |
+          set -euo pipefail
+          mkdir -p build/logs
+          plutil -replace CFBundleDisplayName -string SideStore AltStore/Info.plist || plutil -insert CFBundleDisplayName -string SideStore AltStore/Info.plist
+          NSUnbufferedIO=YES make -B build 2>&1 | tee build/logs/build.log
+          make fakesign 2>&1 | tee -a build/logs/build.log
+          make ipa 2>&1 | tee -a build/logs/build.log
+          test -f SideStore.ipa
+
+      - name: Verify release IPA
+        shell: bash
+        run: |
+          set -euo pipefail
+          IPA=work/SideStore/SideStore.ipa
+          unzip -t "$IPA" >/tmp/v103-unzip.txt
+          rm -rf /tmp/v103-ipa
+          mkdir -p /tmp/v103-ipa
+          unzip -q "$IPA" -d /tmp/v103-ipa
+          find /tmp/v103-ipa/Payload/SideStore.app -type f -size +32k -print0 | xargs -0 strings >/tmp/v103-strings.txt
+          for marker in \
+            '[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED' \
+            '[SIDESTORE_COREDEVICE] TRANSPORT_CREATE_PASS' \
+            '[SIDESTORE_COREDEVICE] ENDPOINT_SELECT' \
+            '[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED' \
+            '[SELF_REFRESH] SELF_REFRESH_COMPLETE' \
+            '[AUTO_REFRESH] REGISTER_PASS' \
+            '[AUTO_REFRESH] COMPLETE' \
+            '[AUTO_REFRESH] AUTH_PREFLIGHT_PASS'; do
+            grep -Fq "$marker" /tmp/v103-strings.txt
+          done
+          cp "$IPA" SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa
+          shasum -a 256 SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa | awk '{print $1 "  SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa"}' > SHA256SUMS.txt
+          cat > RELEASE_NOTES_v1.0.3.md <<EOF
+          # SideStore CoreDevice Auto-Refresh v1.0.3
+
+          Standalone SideStore update based on SideStore 0.7.0 nightly.
+
+          ## What's new
+
+          - Updated upstream SideStore to \`c6f28864dc99ed03ad35f2ca58967247036b7b53\` (0.7.0 nightly, 2026-09-11).
+          - Includes the newer SideStore/SideSign authentication path with the upstream GSA 5XX mitigation.
+          - Retains this project's LocalDevVPN + CoreDevice same-device transport patches.
+          - Retains manual refresh, six-hour/daily/weekly scheduling, refresh history, verification, retry handling, and diagnostics.
+
+          ## Installation
+
+          Sign the IPA with your Apple Account using a compatible installer and install it over the existing matching standalone SideStore installation.
+
+          Do not delete SideStore first if you want to preserve existing app data and setup.
+
+          ## Provenance
+
+          - Builder commit: \`$GITHUB_SHA\`
+          - SideStore upstream: \`$SIDESTORE_REF\`
+          - minimuxer upstream: \`$MINIMUXER_REF\`
+          - idevice: \`$IDEVICE_REF\`
+          - jktcp: \`$JKTCP_REF\`
+
+          Cellular-only refresh remains experimental and is not part of this stable release.
+          EOF
+
+      - name: Publish v1.0.3
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view v1.0.3 --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo 'Release v1.0.3 already exists; refusing to overwrite.'
+            exit 1
+          fi
+          gh release create v1.0.3 \
+            SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa \
+            SHA256SUMS.txt \
+            RELEASE_NOTES_v1.0.3.md \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title 'SideStore CoreDevice Auto-Refresh v1.0.3' \
+            --notes-file RELEASE_NOTES_v1.0.3.md
+
+      - name: Upload build evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: SideStore-v1.0.3-r3-build-evidence
+          path: |
+            work/SideStore/build/logs
+            /tmp/v103-unzip.txt
+            /tmp/v103-strings.txt
+            SHA256SUMS.txt
+            RELEASE_NOTES_v1.0.3.md
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/build-publish-v1.0.3-r4.yml
+++ b/.github/workflows/build-publish-v1.0.3-r4.yml
@@ -1,0 +1,259 @@
+name: Build and publish standalone v1.0.3 r4
+
+on:
+  push:
+    branches: [release/v1.0.3]
+    paths:
+      - '.github/workflows/build-publish-v1.0.3-r4.yml'
+
+permissions:
+  contents: write
+
+env:
+  SIDESTORE_REF: c6f28864dc99ed03ad35f2ca58967247036b7b53
+  MINIMUXER_REF: 9f038e5223a8cacf9d15beae7da6969d617ae1e8
+  IDEVICE_REF: ebd7dadfc55d1c4facee3d11ecf5b28e20548b57
+  JKTCP_REF: e674e1eee6d5943e13b1eba0bd24a9dd0b2fa020
+
+jobs:
+  build-and-publish:
+    runs-on: macos-26
+    timeout-minutes: 75
+    steps:
+      - name: Checkout builder
+        uses: actions/checkout@v4
+        with:
+          path: builder
+          fetch-depth: 1
+
+      - name: Checkout SideStore 0.7.0 nightly
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/SideStore
+          ref: ${{ env.SIDESTORE_REF }}
+          path: work/SideStore
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Checkout idevice
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/idevice
+          ref: ${{ env.IDEVICE_REF }}
+          path: idevice
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Checkout jktcp
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/jktcp
+          ref: ${{ env.JKTCP_REF }}
+          path: jktcp
+          fetch-depth: 1
+
+      - name: Verify exact source revisions
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git -C work/SideStore rev-parse HEAD)" = "$SIDESTORE_REF"
+          test "$(git -C work/SideStore/Dependencies/minimuxer rev-parse HEAD)" = "$MINIMUXER_REF"
+          test "$(git -C idevice rev-parse HEAD)" = "$IDEVICE_REF"
+          test "$(git -C jktcp rev-parse HEAD)" = "$JKTCP_REF"
+          python3 -m py_compile \
+            builder/scripts/adapt_sidestore_070_pairing.py \
+            builder/scripts/patch_jktcp_reliability.py \
+            builder/scripts/patch_coredevice_idevice.py \
+            builder/scripts/patch_sidestore_integration.py \
+            builder/scripts/patch_background_automation.py \
+            builder/scripts/patch_local_idevice_package.py
+
+      - name: Run repository checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover -s builder/tests -v
+
+      - name: Select Xcode 26.4
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: '26.4'
+
+      - name: Install build tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v ldid >/dev/null 2>&1; then HOMEBREW_NO_AUTO_UPDATE=1 brew install ldid; fi
+          if ! command -v bindgen >/dev/null 2>&1; then cargo install --locked bindgen-cli --version 0.72.1; fi
+          rustup target add aarch64-apple-ios
+
+      - name: Patch and test CoreDevice transport
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 builder/scripts/patch_jktcp_reliability.py jktcp
+          python3 builder/scripts/patch_coredevice_idevice.py idevice jktcp
+          cargo fmt --manifest-path jktcp/Cargo.toml
+          cargo fmt --manifest-path idevice/ffi/Cargo.toml
+          git -C jktcp diff --check
+          git -C idevice diff --check
+          cargo test --manifest-path jktcp/Cargo.toml --lib -- --skip tests::local_tcp --skip tests::handle_speed
+          cargo check --manifest-path idevice/ffi/Cargo.toml --features obfuscate
+
+      - name: Build idevice for iOS
+        shell: bash
+        working-directory: idevice
+        run: |
+          set -euo pipefail
+          BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$(xcrun --sdk iphoneos --show-sdk-path)" \
+            IPHONEOS_DEPLOYMENT_TARGET=15.0 \
+            cargo build --release --target aarch64-apple-ios --features obfuscate --manifest-path ffi/Cargo.toml
+          test -f target/aarch64-apple-ios/release/libidevice_ffi.a
+          rm -rf swift/IDevice.xcframework
+          cp ffi/idevice.h swift/include/idevice.h
+          xcodebuild -create-xcframework \
+            -library target/aarch64-apple-ios/release/libidevice_ffi.a \
+            -headers swift/include \
+            -output swift/IDevice.xcframework
+
+      - name: Patch SideStore and verify 0.7.0 compatibility
+        shell: bash
+        run: |
+          set -euo pipefail
+          SIDE=work/SideStore
+          MUX="$SIDE/Dependencies/minimuxer"
+          mkdir -p "$MUX/DeviceGateway/LocalBinary"
+          rm -rf "$MUX/DeviceGateway/LocalBinary/IDevice.xcframework"
+          cp -R idevice/swift/IDevice.xcframework "$MUX/DeviceGateway/LocalBinary/IDevice.xcframework"
+          python3 builder/scripts/adapt_sidestore_070_pairing.py "$MUX"
+          python3 builder/scripts/patch_sidestore_integration.py "$MUX" "$SIDE"
+          python3 builder/scripts/patch_background_automation.py "$SIDE"
+          python3 builder/scripts/patch_local_idevice_package.py "$MUX"
+          git -C "$MUX" diff --check
+          swiftc -frontend -parse "$MUX/DeviceGateway/idevice/IdeviceGateway.swift"
+          swiftc -frontend -parse "$MUX/Common/PairingProtocol.swift"
+          swiftc -frontend -parse "$MUX/Common/PairingFile.swift"
+          swiftc -frontend -parse "$MUX/Sources/Services/NetworkObserverService.swift"
+          swiftc -frontend -parse "$MUX/Sources/MinimuxerImpl.swift"
+          swiftc -frontend -parse "$SIDE/SideStore/Core/Operations/PipelineOperations/ResignAppOperation.swift"
+          swiftc -frontend -parse "$SIDE/SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/AppDelegate.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/SceneDelegate.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/Settings/SettingsViewController.swift"
+          grep -Fq 'Composite records must use Lockdown/CoreDevice' "$MUX/Common/PairingFile.swift"
+          grep -Fq '[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED' "$MUX/DeviceGateway/idevice/IdeviceGateway.swift"
+          grep -Fq '[SIDESTORE_COREDEVICE] ENDPOINT_SELECT' "$MUX/Sources/Services/NetworkObserverService.swift"
+          grep -Fq '[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED' "$MUX/Sources/MinimuxerImpl.swift"
+          grep -Fq '[AUTO_REFRESH] AUTH_PREFLIGHT_PASS' "$SIDE/SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift"
+
+      - name: Resolve Swift packages
+        shell: bash
+        working-directory: work/SideStore
+        run: |
+          set -euo pipefail
+          ok=0
+          for attempt in 1 2 3; do
+            if xcodebuild -resolvePackageDependencies -disablePackageRepositoryCache -project AltStore.xcodeproj -scheme SideStore; then
+              ok=1
+              break
+            fi
+            sleep 2
+          done
+          test "$ok" -eq 1
+
+      - name: Build standalone SideStore IPA
+        shell: bash
+        working-directory: work/SideStore
+        run: |
+          set -euo pipefail
+          mkdir -p build/logs
+          plutil -replace CFBundleDisplayName -string SideStore AltStore/Info.plist || plutil -insert CFBundleDisplayName -string SideStore AltStore/Info.plist
+          NSUnbufferedIO=YES make -B build 2>&1 | tee build/logs/build.log
+          make fakesign 2>&1 | tee -a build/logs/build.log
+          make ipa 2>&1 | tee -a build/logs/build.log
+          test -f SideStore.ipa
+
+      - name: Verify release IPA
+        shell: bash
+        run: |
+          set -euo pipefail
+          IPA=work/SideStore/SideStore.ipa
+          unzip -t "$IPA" >/tmp/v103-unzip.txt
+          rm -rf /tmp/v103-ipa
+          mkdir -p /tmp/v103-ipa
+          unzip -q "$IPA" -d /tmp/v103-ipa
+          find /tmp/v103-ipa/Payload/SideStore.app -type f -size +32k -print0 | xargs -0 strings >/tmp/v103-strings.txt
+          for marker in \
+            '[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED' \
+            '[SIDESTORE_COREDEVICE] TRANSPORT_CREATE_PASS' \
+            '[SIDESTORE_COREDEVICE] ENDPOINT_SELECT' \
+            '[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED' \
+            '[SELF_REFRESH] SELF_REFRESH_COMPLETE' \
+            '[AUTO_REFRESH] REGISTER_PASS' \
+            '[AUTO_REFRESH] COMPLETE' \
+            '[AUTO_REFRESH] AUTH_PREFLIGHT_PASS'; do
+            grep -Fq "$marker" /tmp/v103-strings.txt
+          done
+          cp "$IPA" SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa
+          shasum -a 256 SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa | awk '{print $1 "  SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa"}' > SHA256SUMS.txt
+          cat > RELEASE_NOTES_v1.0.3.md <<EOF
+          # SideStore CoreDevice Auto-Refresh v1.0.3
+
+          Standalone SideStore update based on SideStore 0.7.0 nightly.
+
+          ## What's new
+
+          - Updated upstream SideStore to \`$SIDESTORE_REF\` (0.7.0 nightly, 2026-09-11).
+          - Includes the newer SideStore/SideSign authentication path with the upstream GSA 5XX mitigation.
+          - Retains this project's LocalDevVPN + CoreDevice same-device transport patches.
+          - Retains manual refresh, six-hour/daily/weekly scheduling, refresh history, verification, retry handling, and diagnostics.
+
+          ## Installation
+
+          Sign the IPA with your Apple Account using a compatible installer and install it over the existing matching standalone SideStore installation.
+
+          Do not delete SideStore first if you want to preserve existing app data and setup.
+
+          ## Provenance
+
+          - Builder commit: \`$GITHUB_SHA\`
+          - SideStore upstream: \`$SIDESTORE_REF\`
+          - minimuxer upstream: \`$MINIMUXER_REF\`
+          - idevice: \`$IDEVICE_REF\`
+          - jktcp: \`$JKTCP_REF\`
+
+          Cellular-only refresh remains experimental and is not part of this stable release.
+          EOF
+
+      - name: Publish v1.0.3
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view v1.0.3 --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo 'Release v1.0.3 already exists; refusing to overwrite.'
+            exit 1
+          fi
+          gh release create v1.0.3 \
+            SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa \
+            SHA256SUMS.txt \
+            RELEASE_NOTES_v1.0.3.md \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title 'SideStore CoreDevice Auto-Refresh v1.0.3' \
+            --notes-file RELEASE_NOTES_v1.0.3.md
+
+      - name: Upload build evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: SideStore-v1.0.3-r4-build-evidence
+          path: |
+            work/SideStore/build/logs
+            /tmp/v103-unzip.txt
+            /tmp/v103-strings.txt
+            SHA256SUMS.txt
+            RELEASE_NOTES_v1.0.3.md
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/build-publish-v1.0.3-r5.yml
+++ b/.github/workflows/build-publish-v1.0.3-r5.yml
@@ -1,0 +1,259 @@
+name: Build and publish standalone v1.0.3 r5
+
+on:
+  push:
+    branches: [release/v1.0.3]
+    paths:
+      - '.github/workflows/build-publish-v1.0.3-r5.yml'
+
+permissions:
+  contents: write
+
+env:
+  SIDESTORE_REF: c6f28864dc99ed03ad35f2ca58967247036b7b53
+  MINIMUXER_REF: 9f038e5223a8cacf9d15beae7da6969d617ae1e8
+  IDEVICE_REF: ebd7dadfc55d1c4facee3d11ecf5b28e20548b57
+  JKTCP_REF: e674e1eee6d5943e13b1eba0bd24a9dd0b2fa020
+
+jobs:
+  build-and-publish:
+    runs-on: macos-26
+    timeout-minutes: 75
+    steps:
+      - name: Checkout builder
+        uses: actions/checkout@v4
+        with:
+          path: builder
+          fetch-depth: 1
+
+      - name: Checkout SideStore 0.7.0 nightly
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/SideStore
+          ref: ${{ env.SIDESTORE_REF }}
+          path: work/SideStore
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Checkout idevice
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/idevice
+          ref: ${{ env.IDEVICE_REF }}
+          path: idevice
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Checkout jktcp
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/jktcp
+          ref: ${{ env.JKTCP_REF }}
+          path: jktcp
+          fetch-depth: 1
+
+      - name: Verify exact source revisions
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git -C work/SideStore rev-parse HEAD)" = "$SIDESTORE_REF"
+          test "$(git -C work/SideStore/Dependencies/minimuxer rev-parse HEAD)" = "$MINIMUXER_REF"
+          test "$(git -C idevice rev-parse HEAD)" = "$IDEVICE_REF"
+          test "$(git -C jktcp rev-parse HEAD)" = "$JKTCP_REF"
+          python3 -m py_compile \
+            builder/scripts/adapt_sidestore_070_pairing.py \
+            builder/scripts/patch_jktcp_reliability.py \
+            builder/scripts/patch_coredevice_idevice.py \
+            builder/scripts/patch_sidestore_integration.py \
+            builder/scripts/patch_background_automation.py \
+            builder/scripts/patch_local_idevice_package.py
+
+      - name: Run repository checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover -s builder/tests -v
+
+      - name: Select Xcode 26.4
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: '26.4'
+
+      - name: Install build tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v ldid >/dev/null 2>&1; then HOMEBREW_NO_AUTO_UPDATE=1 brew install ldid; fi
+          if ! command -v bindgen >/dev/null 2>&1; then cargo install --locked bindgen-cli --version 0.72.1; fi
+          rustup target add aarch64-apple-ios
+
+      - name: Patch and test CoreDevice transport
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 builder/scripts/patch_jktcp_reliability.py jktcp
+          python3 builder/scripts/patch_coredevice_idevice.py idevice jktcp
+          cargo fmt --manifest-path jktcp/Cargo.toml
+          cargo fmt --manifest-path idevice/ffi/Cargo.toml
+          git -C jktcp diff --check
+          git -C idevice diff --check
+          cargo test --manifest-path jktcp/Cargo.toml --lib -- --skip tests::local_tcp --skip tests::handle_speed
+          cargo check --manifest-path idevice/ffi/Cargo.toml --features obfuscate
+
+      - name: Build idevice for iOS
+        shell: bash
+        working-directory: idevice
+        run: |
+          set -euo pipefail
+          BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$(xcrun --sdk iphoneos --show-sdk-path)" \
+            IPHONEOS_DEPLOYMENT_TARGET=15.0 \
+            cargo build --release --target aarch64-apple-ios --features obfuscate --manifest-path ffi/Cargo.toml
+          test -f target/aarch64-apple-ios/release/libidevice_ffi.a
+          rm -rf swift/IDevice.xcframework
+          cp ffi/idevice.h swift/include/idevice.h
+          xcodebuild -create-xcframework \
+            -library target/aarch64-apple-ios/release/libidevice_ffi.a \
+            -headers swift/include \
+            -output swift/IDevice.xcframework
+
+      - name: Patch SideStore and verify 0.7.0 compatibility
+        shell: bash
+        run: |
+          set -euo pipefail
+          SIDE=work/SideStore
+          MUX="$SIDE/Dependencies/minimuxer"
+          mkdir -p "$MUX/DeviceGateway/LocalBinary"
+          rm -rf "$MUX/DeviceGateway/LocalBinary/IDevice.xcframework"
+          cp -R idevice/swift/IDevice.xcframework "$MUX/DeviceGateway/LocalBinary/IDevice.xcframework"
+          python3 builder/scripts/adapt_sidestore_070_pairing.py "$MUX"
+          python3 builder/scripts/patch_sidestore_integration.py "$MUX" "$SIDE"
+          python3 builder/scripts/patch_background_automation.py "$SIDE"
+          python3 builder/scripts/patch_local_idevice_package.py "$MUX"
+          git -C "$MUX" diff --check
+          swiftc -frontend -parse "$MUX/DeviceGateway/idevice/IdeviceGateway.swift"
+          swiftc -frontend -parse "$MUX/Common/PairingProtocol.swift"
+          swiftc -frontend -parse "$MUX/Common/PairingFile.swift"
+          swiftc -frontend -parse "$MUX/Sources/Services/NetworkObserverService.swift"
+          swiftc -frontend -parse "$MUX/Sources/MinimuxerImpl.swift"
+          swiftc -frontend -parse "$SIDE/SideStore/Core/Operations/PipelineOperations/ResignAppOperation.swift"
+          swiftc -frontend -parse "$SIDE/SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/AppDelegate.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/SceneDelegate.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/Settings/SettingsViewController.swift"
+          grep -Fq 'Composite records must use Lockdown/CoreDevice' "$MUX/Common/PairingFile.swift"
+          grep -Fq '[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED' "$MUX/DeviceGateway/idevice/IdeviceGateway.swift"
+          grep -Fq '[SIDESTORE_COREDEVICE] ENDPOINT_SELECT' "$MUX/Sources/Services/NetworkObserverService.swift"
+          grep -Fq '[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED' "$MUX/Sources/MinimuxerImpl.swift"
+          grep -Fq '[AUTO_REFRESH] AUTH_PREFLIGHT_PASS' "$SIDE/SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift"
+
+      - name: Resolve Swift packages
+        shell: bash
+        working-directory: work/SideStore
+        run: |
+          set -euo pipefail
+          ok=0
+          for attempt in 1 2 3; do
+            if xcodebuild -resolvePackageDependencies -disablePackageRepositoryCache -project AltStore.xcodeproj -scheme SideStore; then
+              ok=1
+              break
+            fi
+            sleep 2
+          done
+          test "$ok" -eq 1
+
+      - name: Build standalone SideStore IPA
+        shell: bash
+        working-directory: work/SideStore
+        run: |
+          set -euo pipefail
+          mkdir -p build/logs
+          plutil -replace CFBundleDisplayName -string SideStore AltStore/Info.plist || plutil -insert CFBundleDisplayName -string SideStore AltStore/Info.plist
+          NSUnbufferedIO=YES make -B build 2>&1 | tee build/logs/build.log
+          make fakesign 2>&1 | tee -a build/logs/build.log
+          make ipa 2>&1 | tee -a build/logs/build.log
+          test -f SideStore.ipa
+
+      - name: Verify release IPA
+        shell: bash
+        run: |
+          set -euo pipefail
+          IPA=work/SideStore/SideStore.ipa
+          unzip -t "$IPA" >/tmp/v103-unzip.txt
+          rm -rf /tmp/v103-ipa
+          mkdir -p /tmp/v103-ipa
+          unzip -q "$IPA" -d /tmp/v103-ipa
+          find /tmp/v103-ipa/Payload/SideStore.app -type f -size +32k -print0 | xargs -0 strings >/tmp/v103-strings.txt
+          for marker in \
+            '[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED' \
+            '[SIDESTORE_COREDEVICE] TRANSPORT_CREATE_PASS' \
+            '[SIDESTORE_COREDEVICE] ENDPOINT_SELECT' \
+            '[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED' \
+            '[SELF_REFRESH] SELF_REFRESH_COMPLETE' \
+            '[AUTO_REFRESH] REGISTER_PASS' \
+            '[AUTO_REFRESH] COMPLETE' \
+            '[AUTO_REFRESH] AUTH_PREFLIGHT_PASS'; do
+            grep -Fq "$marker" /tmp/v103-strings.txt
+          done
+          cp "$IPA" SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa
+          shasum -a 256 SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa | awk '{print $1 "  SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa"}' > SHA256SUMS.txt
+          cat > RELEASE_NOTES_v1.0.3.md <<EOF
+          # SideStore CoreDevice Auto-Refresh v1.0.3
+
+          Standalone SideStore update based on SideStore 0.7.0 nightly.
+
+          ## What's new
+
+          - Updated upstream SideStore to \`$SIDESTORE_REF\` (0.7.0 nightly, 2026-09-11).
+          - Includes the newer SideStore/SideSign authentication path with the upstream GSA 5XX mitigation.
+          - Retains this project's LocalDevVPN + CoreDevice same-device transport patches.
+          - Retains manual refresh, six-hour/daily/weekly scheduling, refresh history, verification, retry handling, and diagnostics.
+
+          ## Installation
+
+          Sign the IPA with your Apple Account using a compatible installer and install it over the existing matching standalone SideStore installation.
+
+          Do not delete SideStore first if you want to preserve existing app data and setup.
+
+          ## Provenance
+
+          - Builder commit: \`$GITHUB_SHA\`
+          - SideStore upstream: \`$SIDESTORE_REF\`
+          - minimuxer upstream: \`$MINIMUXER_REF\`
+          - idevice: \`$IDEVICE_REF\`
+          - jktcp: \`$JKTCP_REF\`
+
+          Cellular-only refresh remains experimental and is not part of this stable release.
+          EOF
+
+      - name: Publish v1.0.3
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view v1.0.3 --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo 'Release v1.0.3 already exists; refusing to overwrite.'
+            exit 1
+          fi
+          gh release create v1.0.3 \
+            SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa \
+            SHA256SUMS.txt \
+            RELEASE_NOTES_v1.0.3.md \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title 'SideStore CoreDevice Auto-Refresh v1.0.3' \
+            --notes-file RELEASE_NOTES_v1.0.3.md
+
+      - name: Upload build evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: SideStore-v1.0.3-r5-build-evidence
+          path: |
+            work/SideStore/build/logs
+            /tmp/v103-unzip.txt
+            /tmp/v103-strings.txt
+            SHA256SUMS.txt
+            RELEASE_NOTES_v1.0.3.md
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/build-publish-v1.0.3-r6.yml
+++ b/.github/workflows/build-publish-v1.0.3-r6.yml
@@ -1,0 +1,314 @@
+name: Build and publish standalone v1.0.3 r6
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [release/v1.0.3]
+    paths:
+      - '.github/workflows/build-publish-v1.0.3-r6.yml'
+      - 'tests/**'
+      - 'scripts/**'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: standalone-v1.0.3-publish
+  cancel-in-progress: false
+
+env:
+  SIDESTORE_REF: c6f28864dc99ed03ad35f2ca58967247036b7b53
+  MINIMUXER_REF: 9f038e5223a8cacf9d15beae7da6969d617ae1e8
+  SIDESIGN_REF: 8385fab56e7bd5aea8110e1b85ab069a71e45ce0
+  IDEVICE_REF: ebd7dadfc55d1c4facee3d11ecf5b28e20548b57
+  JKTCP_REF: e674e1eee6d5943e13b1eba0bd24a9dd0b2fa020
+  LIVE_CONTAINER_TEST_REF: 12377cf3b91d51739a33f14a302e5f522b238593
+  EMBEDDED_SIDESTORE_TEST_REF: 10ffa01ecdfe4203a7ad5d7f41c0d5de03bd8abb
+
+jobs:
+  build-and-publish:
+    runs-on: macos-26
+    timeout-minutes: 75
+    steps:
+      - name: Checkout builder
+        uses: actions/checkout@v4
+        with:
+          path: builder
+          fetch-depth: 0
+
+      - name: Checkout SideStore 0.7.0 nightly
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/SideStore
+          ref: ${{ env.SIDESTORE_REF }}
+          path: work/SideStore
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Checkout idevice
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/idevice
+          ref: ${{ env.IDEVICE_REF }}
+          path: idevice
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Checkout jktcp
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/jktcp
+          ref: ${{ env.JKTCP_REF }}
+          path: jktcp
+          fetch-depth: 1
+
+      - name: Select Xcode 26.4
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: '26.4'
+
+      - name: Checkout combined regression fixtures
+        uses: actions/checkout@v4
+        with:
+          repository: LiveContainer/SideStore
+          ref: ${{ env.EMBEDDED_SIDESTORE_TEST_REF }}
+          path: work/EmbeddedSideStore
+          submodules: recursive
+
+      - name: Checkout host regression fixtures
+        uses: actions/checkout@v4
+        with:
+          repository: LiveContainer/LiveContainer
+          ref: ${{ env.LIVE_CONTAINER_TEST_REF }}
+          path: work/LiveContainer
+          submodules: recursive
+
+      - name: Verify revisions and scripts
+        env:
+          SIDESTORE_TEST_SOURCE: ${{ github.workspace }}/work/SideStore
+          SIDESTORE_070_TEST_SOURCE: ${{ github.workspace }}/work/SideStore
+          EMBEDDED_SIDESTORE_TEST_SOURCE: ${{ github.workspace }}/work/EmbeddedSideStore
+          LIVE_CONTAINER_TEST_SOURCE: ${{ github.workspace }}/work/LiveContainer
+          REQUIRE_SWIFT_070_CHECKS: '1'
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git -C work/SideStore rev-parse HEAD)" = "$SIDESTORE_REF"
+          test "$(git -C work/SideStore/Dependencies/minimuxer rev-parse HEAD)" = "$MINIMUXER_REF"
+          test "$(git -C work/SideStore/Dependencies/SideSign rev-parse HEAD)" = "$SIDESIGN_REF"
+          test "$(git -C idevice rev-parse HEAD)" = "$IDEVICE_REF"
+          test "$(git -C jktcp rev-parse HEAD)" = "$JKTCP_REF"
+          test "$(git -C work/LiveContainer rev-parse HEAD)" = "$LIVE_CONTAINER_TEST_REF"
+          test "$(git -C work/EmbeddedSideStore rev-parse HEAD)" = "$EMBEDDED_SIDESTORE_TEST_REF"
+          python3 -m py_compile \
+            builder/scripts/adapt_sidestore_070_pairing.py \
+            builder/scripts/adapt_sidestore_070_signing.py \
+            builder/scripts/patch_jktcp_reliability.py \
+            builder/scripts/patch_coredevice_idevice.py \
+            builder/scripts/patch_sidestore_integration.py \
+            builder/scripts/patch_background_automation.py \
+            builder/scripts/patch_local_idevice_package.py
+          mkdir -p evidence
+          python3 -m unittest discover -s builder/tests -v 2>&1 | tee evidence/repository-tests.log
+
+      - name: Install build tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v ldid >/dev/null 2>&1; then HOMEBREW_NO_AUTO_UPDATE=1 brew install ldid; fi
+          if ! command -v bindgen >/dev/null 2>&1; then cargo install --locked bindgen-cli --version 0.72.1; fi
+          rustup target add aarch64-apple-ios
+
+      - name: Patch and test CoreDevice transport
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 builder/scripts/patch_jktcp_reliability.py jktcp
+          python3 builder/scripts/patch_coredevice_idevice.py idevice jktcp
+          cargo fmt --manifest-path jktcp/Cargo.toml
+          cargo fmt --manifest-path idevice/ffi/Cargo.toml
+          git -C jktcp diff --check
+          git -C idevice diff --check
+          cargo test --manifest-path jktcp/Cargo.toml --lib -- --skip tests::local_tcp --skip tests::handle_speed
+          cargo check --manifest-path idevice/ffi/Cargo.toml --features obfuscate
+
+      - name: Build idevice for iOS
+        shell: bash
+        working-directory: idevice
+        run: |
+          set -euo pipefail
+          BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$(xcrun --sdk iphoneos --show-sdk-path)" \
+            IPHONEOS_DEPLOYMENT_TARGET=15.0 \
+            cargo build --release --target aarch64-apple-ios --features obfuscate --manifest-path ffi/Cargo.toml
+          test -f target/aarch64-apple-ios/release/libidevice_ffi.a
+          rm -rf swift/IDevice.xcframework
+          cp ffi/idevice.h swift/include/idevice.h
+          xcodebuild -create-xcframework \
+            -library target/aarch64-apple-ios/release/libidevice_ffi.a \
+            -headers swift/include \
+            -output swift/IDevice.xcframework
+
+      - name: Patch and verify SideStore 0.7.0
+        shell: bash
+        run: |
+          set -euo pipefail
+          SIDE=work/SideStore
+          MUX="$SIDE/Dependencies/minimuxer"
+          mkdir -p "$MUX/DeviceGateway/LocalBinary"
+          rm -rf "$MUX/DeviceGateway/LocalBinary/IDevice.xcframework"
+          cp -R idevice/swift/IDevice.xcframework "$MUX/DeviceGateway/LocalBinary/IDevice.xcframework"
+
+          python3 builder/scripts/adapt_sidestore_070_pairing.py "$MUX"
+          python3 builder/scripts/adapt_sidestore_070_signing.py "$SIDE"
+          python3 builder/scripts/patch_sidestore_integration.py "$MUX" "$SIDE"
+          python3 builder/scripts/patch_background_automation.py "$SIDE"
+          python3 builder/scripts/patch_local_idevice_package.py "$MUX"
+
+          GATEWAY="$MUX/DeviceGateway/idevice/IdeviceGateway.swift"
+          PAIRING="$MUX/Common/PairingFile.swift"
+          PROTOCOL="$MUX/Common/PairingProtocol.swift"
+          OBSERVER="$MUX/Sources/Services/NetworkObserverService.swift"
+          IMPL="$MUX/Sources/MinimuxerImpl.swift"
+
+          git -C "$MUX" diff --check
+          swiftc -frontend -parse "$GATEWAY"
+          swiftc -frontend -parse "$PAIRING"
+          swiftc -frontend -parse "$PROTOCOL"
+          swiftc -frontend -parse "$OBSERVER"
+          swiftc -frontend -parse "$IMPL"
+          swiftc -frontend -parse "$SIDE/SideStore/Core/Operations/PipelineOperations/ResignAppOperation.swift"
+          swiftc -frontend -parse "$SIDE/SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/AppDelegate.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/SceneDelegate.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/Settings/SettingsViewController.swift"
+
+          grep -Fq 'Composite records must use Lockdown/CoreDevice' "$PAIRING"
+          grep -Fq '[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED' "$GATEWAY"
+          grep -Fq '[SIDESTORE_COREDEVICE] ENDPOINT_SELECT' "$OBSERVER"
+          grep -Fq '[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED' "$IMPL"
+          ! grep -Fq 'no ipsec interface (required for lockdown on iOS 26.4+)' "$IMPL"
+          grep -Fq '[SELF_REFRESH] SIDESTORE_SIGN_PASS' "$SIDE/SideStore/Core/Operations/PipelineOperations/ResignAppOperation.swift"
+          grep -Fq '[AUTO_REFRESH] AUTH_PREFLIGHT_PASS' "$SIDE/SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift"
+
+          python3 - "$PAIRING" <<'PY'
+          from pathlib import Path
+          import sys
+          text = Path(sys.argv[1]).read_text(encoding='utf-8')
+          lockdown = text.index('let missingLockdown = LockdownPairingFile.missingKeys(in: plist)')
+          remote = text.index('let missingRP = RPPairingFile.missingKeys(in: plist)', lockdown)
+          assert lockdown < remote
+          PY
+
+          swiftc "$MUX/Common/MinimuxerConstants.swift" "$PROTOCOL" "$PAIRING" \
+            builder/tests/standalone_pairing_policy.swift -o /tmp/pairing-policy-test
+          /tmp/pairing-policy-test
+          git -C "$SIDE/Dependencies/SideSign" diff --exit-code
+          git -C "$SIDE" diff --exit-code -- SideStore/Core/Auth
+
+      - name: Resolve Swift packages
+        shell: bash
+        working-directory: work/SideStore
+        run: |
+          set -euo pipefail
+          ok=0
+          for attempt in 1 2 3; do
+            if xcodebuild -resolvePackageDependencies -disablePackageRepositoryCache -project AltStore.xcodeproj -scheme SideStore; then
+              ok=1
+              break
+            fi
+            sleep 2
+          done
+          test "$ok" -eq 1
+
+      - name: Build standalone IPA
+        shell: bash
+        working-directory: work/SideStore
+        run: |
+          set -euo pipefail
+          mkdir -p build/logs
+          plutil -replace CFBundleDisplayName -string SideStore AltStore/Info.plist || plutil -insert CFBundleDisplayName -string SideStore AltStore/Info.plist
+          NSUnbufferedIO=YES make -B build 2>&1 | tee build/logs/build.log
+          make fakesign 2>&1 | tee -a build/logs/build.log
+          make ipa 2>&1 | tee -a build/logs/build.log
+          test -f SideStore.ipa
+
+      - name: Verify and package release
+        shell: bash
+        run: |
+          set -euo pipefail
+          IPA=work/SideStore/SideStore.ipa
+          unzip -t "$IPA" >/tmp/v103-unzip.txt
+          rm -rf /tmp/v103-ipa && mkdir -p /tmp/v103-ipa
+          unzip -q "$IPA" -d /tmp/v103-ipa
+          find /tmp/v103-ipa/Payload/SideStore.app -type f -size +32k -print0 | xargs -0 strings >/tmp/v103-strings.txt
+          for marker in \
+            '[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED' \
+            '[SIDESTORE_COREDEVICE] TRANSPORT_CREATE_PASS' \
+            '[SIDESTORE_COREDEVICE] ENDPOINT_SELECT' \
+            '[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED' \
+            '[SELF_REFRESH] SIDESTORE_SIGN_PASS' \
+            '[SELF_REFRESH] SELF_REFRESH_COMPLETE' \
+            '[AUTO_REFRESH] REGISTER_PASS' \
+            '[AUTO_REFRESH] COMPLETE' \
+            '[AUTO_REFRESH] DATABASE_START_FAIL' \
+            '[AUTO_REFRESH] REFRESH_VERIFIED' \
+            '[AUTO_REFRESH] VERIFICATION_MANIFEST_V1' \
+            '[AUTO_REFRESH] SIDESTORE_REFRESH_RECOVERY' \
+            '[AUTO_REFRESH] AUTH_PREFLIGHT_PASS'; do
+            grep -Fq "$marker" /tmp/v103-strings.txt
+          done
+          cp "$IPA" SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa
+          shasum -a 256 SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa | awk '{print $1 "  SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa"}' > SHA256SUMS.txt
+          cat > RELEASE_NOTES_v1.0.3.md <<EOF
+          # SideStore CoreDevice Auto-Refresh v1.0.3
+
+          Standalone SideStore update based on SideStore 0.7.0 nightly.
+
+          - SideStore upstream: \`$SIDESTORE_REF\`
+          - minimuxer: \`$MINIMUXER_REF\`
+          - SideSign: \`$SIDESIGN_REF\`
+          - idevice: \`$IDEVICE_REF\`
+          - jktcp: \`$JKTCP_REF\`
+          - Builder: \`$GITHUB_SHA\`
+          - Includes the newer upstream authentication path used by SideStore 0.7.0.
+          - Retains LocalDevVPN + Lockdown/CoreDevice transport.
+          - Retains manual and scheduled auto-refresh, history, verification, retries, and diagnostics.
+          - Composite pairing records prefer Lockdown/CoreDevice.
+          - Cellular-only refresh remains experimental.
+
+          Install over the existing standalone SideStore if you want to preserve existing app data and configuration.
+          EOF
+
+      - name: Publish v1.0.3
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view v1.0.3 --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo 'Release v1.0.3 already exists; refusing to overwrite.'
+            exit 1
+          fi
+          gh release create v1.0.3 \
+            SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa \
+            SHA256SUMS.txt \
+            RELEASE_NOTES_v1.0.3.md \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title 'SideStore CoreDevice Auto-Refresh v1.0.3' \
+            --notes-file RELEASE_NOTES_v1.0.3.md
+
+      - name: Upload evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: SideStore-v1.0.3-r6-build-evidence
+          path: |
+            evidence
+            work/SideStore/build/logs
+            /tmp/v103-unzip.txt
+            /tmp/v103-strings.txt
+            SHA256SUMS.txt
+            RELEASE_NOTES_v1.0.3.md
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/build-publish-v1.0.3.yml
+++ b/.github/workflows/build-publish-v1.0.3.yml
@@ -1,0 +1,245 @@
+name: Build and publish standalone v1.0.3
+
+on:
+  push:
+    branches: [release/v1.0.3]
+    paths:
+      - '.github/workflows/build-publish-v1.0.3.yml'
+
+permissions:
+  contents: write
+
+env:
+  SIDESTORE_REF: c6f28864dc99ed03ad35f2ca58967247036b7b53
+  MINIMUXER_REF: 9f038e5223a8cacf9d15beae7da6969d617ae1e8
+  IDEVICE_REF: ebd7dadfc55d1c4facee3d11ecf5b28e20548b57
+  JKTCP_REF: e674e1eee6d5943e13b1eba0bd24a9dd0b2fa020
+
+jobs:
+  build-and-publish:
+    runs-on: macos-26
+    timeout-minutes: 75
+    steps:
+      - name: Checkout builder
+        uses: actions/checkout@v4
+        with:
+          path: builder
+          fetch-depth: 1
+
+      - name: Checkout SideStore 0.7.0 nightly
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/SideStore
+          ref: ${{ env.SIDESTORE_REF }}
+          path: work/SideStore
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Checkout idevice
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/idevice
+          ref: ${{ env.IDEVICE_REF }}
+          path: idevice
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Checkout jktcp
+        uses: actions/checkout@v4
+        with:
+          repository: SideStore/jktcp
+          ref: ${{ env.JKTCP_REF }}
+          path: jktcp
+          fetch-depth: 1
+
+      - name: Verify source revisions and repository tests
+        shell: bash
+        env:
+          SIDESTORE_TEST_SOURCE: ${{ github.workspace }}/work/SideStore
+        run: |
+          set -euo pipefail
+          test "$(git -C work/SideStore rev-parse HEAD)" = "$SIDESTORE_REF"
+          test "$(git -C work/SideStore/Dependencies/minimuxer rev-parse HEAD)" = "$MINIMUXER_REF"
+          test "$(git -C idevice rev-parse HEAD)" = "$IDEVICE_REF"
+          test "$(git -C jktcp rev-parse HEAD)" = "$JKTCP_REF"
+          python3 -m unittest discover -s builder/tests -v
+
+      - name: Select Xcode 26.4
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: '26.4'
+
+      - name: Install build tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v ldid >/dev/null 2>&1; then HOMEBREW_NO_AUTO_UPDATE=1 brew install ldid; fi
+          if ! command -v bindgen >/dev/null 2>&1; then cargo install --locked bindgen-cli --version 0.72.1; fi
+          rustup target add aarch64-apple-ios
+
+      - name: Patch and test CoreDevice transport
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 builder/scripts/patch_jktcp_reliability.py jktcp
+          python3 builder/scripts/patch_coredevice_idevice.py idevice jktcp
+          cargo fmt --manifest-path jktcp/Cargo.toml
+          cargo fmt --manifest-path idevice/ffi/Cargo.toml
+          git -C jktcp diff --check
+          git -C idevice diff --check
+          cargo test --manifest-path jktcp/Cargo.toml --lib -- --skip tests::local_tcp --skip tests::handle_speed
+          cargo check --manifest-path idevice/ffi/Cargo.toml --features obfuscate
+
+      - name: Build idevice for iOS
+        shell: bash
+        working-directory: idevice
+        run: |
+          set -euo pipefail
+          BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$(xcrun --sdk iphoneos --show-sdk-path)" \
+            IPHONEOS_DEPLOYMENT_TARGET=15.0 \
+            cargo build --release --target aarch64-apple-ios --features obfuscate --manifest-path ffi/Cargo.toml
+          test -f target/aarch64-apple-ios/release/libidevice_ffi.a
+          rm -rf swift/IDevice.xcframework
+          cp ffi/idevice.h swift/include/idevice.h
+          xcodebuild -create-xcframework \
+            -library target/aarch64-apple-ios/release/libidevice_ffi.a \
+            -headers swift/include \
+            -output swift/IDevice.xcframework
+
+      - name: Patch SideStore and verify patches
+        shell: bash
+        run: |
+          set -euo pipefail
+          SIDE=work/SideStore
+          MUX="$SIDE/Dependencies/minimuxer"
+          mkdir -p "$MUX/DeviceGateway/LocalBinary"
+          rm -rf "$MUX/DeviceGateway/LocalBinary/IDevice.xcframework"
+          cp -R idevice/swift/IDevice.xcframework "$MUX/DeviceGateway/LocalBinary/IDevice.xcframework"
+          python3 builder/scripts/patch_sidestore_integration.py "$MUX" "$SIDE"
+          python3 builder/scripts/patch_background_automation.py "$SIDE"
+          python3 builder/scripts/patch_local_idevice_package.py "$MUX"
+          git -C "$MUX" diff --check
+          swiftc -frontend -parse "$MUX/DeviceGateway/idevice/IdeviceGateway.swift"
+          swiftc -frontend -parse "$MUX/Common/PairingProtocol.swift"
+          swiftc -frontend -parse "$MUX/Sources/Services/NetworkObserverService.swift"
+          swiftc -frontend -parse "$MUX/Sources/MinimuxerImpl.swift"
+          swiftc -frontend -parse "$SIDE/SideStore/Core/Operations/PipelineOperations/ResignAppOperation.swift"
+          swiftc -frontend -parse "$SIDE/SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/AppDelegate.swift"
+          swiftc -frontend -parse "$SIDE/AltStore/SceneDelegate.swift"
+          grep -Fq '[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED' "$MUX/DeviceGateway/idevice/IdeviceGateway.swift"
+          grep -Fq '[SIDESTORE_COREDEVICE] ENDPOINT_SELECT' "$MUX/Sources/Services/NetworkObserverService.swift"
+          grep -Fq '[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED' "$MUX/Sources/MinimuxerImpl.swift"
+          grep -Fq '[AUTO_REFRESH] AUTH_PREFLIGHT_PASS' "$SIDE/SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift"
+
+      - name: Resolve Swift packages
+        shell: bash
+        working-directory: work/SideStore
+        run: |
+          set -euo pipefail
+          ok=0
+          for attempt in 1 2 3; do
+            if xcodebuild -resolvePackageDependencies -disablePackageRepositoryCache -project AltStore.xcodeproj -scheme SideStore; then
+              ok=1
+              break
+            fi
+            sleep 2
+          done
+          test "$ok" -eq 1
+
+      - name: Build standalone SideStore IPA
+        shell: bash
+        working-directory: work/SideStore
+        run: |
+          set -euo pipefail
+          mkdir -p build/logs
+          plutil -replace CFBundleDisplayName -string SideStore AltStore/Info.plist || plutil -insert CFBundleDisplayName -string SideStore AltStore/Info.plist
+          NSUnbufferedIO=YES make -B build 2>&1 | tee build/logs/build.log
+          make fakesign 2>&1 | tee -a build/logs/build.log
+          make ipa 2>&1 | tee -a build/logs/build.log
+          test -f SideStore.ipa
+
+      - name: Verify and prepare release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          IPA=work/SideStore/SideStore.ipa
+          unzip -t "$IPA" >/tmp/v103-unzip.txt
+          rm -rf /tmp/v103-ipa
+          mkdir -p /tmp/v103-ipa
+          unzip -q "$IPA" -d /tmp/v103-ipa
+          find /tmp/v103-ipa/Payload/SideStore.app -type f -size +32k -print0 | xargs -0 strings >/tmp/v103-strings.txt
+          for marker in \
+            '[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED' \
+            '[SIDESTORE_COREDEVICE] TRANSPORT_CREATE_PASS' \
+            '[SIDESTORE_COREDEVICE] ENDPOINT_SELECT' \
+            '[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED' \
+            '[SELF_REFRESH] SELF_REFRESH_COMPLETE' \
+            '[AUTO_REFRESH] REGISTER_PASS' \
+            '[AUTO_REFRESH] COMPLETE' \
+            '[AUTO_REFRESH] AUTH_PREFLIGHT_PASS'; do
+            grep -Fq "$marker" /tmp/v103-strings.txt
+          done
+          cp "$IPA" SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa
+          shasum -a 256 SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa | awk '{print $1 "  SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa"}' > SHA256SUMS.txt
+          cat > RELEASE_NOTES_v1.0.3.md <<EOF
+          # SideStore CoreDevice Auto-Refresh v1.0.3
+
+          Standalone SideStore update based on SideStore 0.7.0 nightly.
+
+          ## What's new
+
+          - Updated upstream SideStore to \`c6f28864dc99ed03ad35f2ca58967247036b7b53\` (0.7.0 nightly, 2026-09-11).
+          - Includes the newer SideStore/SideSign authentication path with the upstream GSA 5XX mitigation.
+          - Retains this project's LocalDevVPN + CoreDevice same-device transport patches.
+          - Retains manual refresh, six-hour/daily/weekly scheduling, refresh history, verification, retry handling, and diagnostics.
+
+          ## Installation
+
+          Sign the IPA with your Apple Account using a compatible installer and install it over the existing matching standalone SideStore installation.
+
+          Do not delete SideStore first if you want to preserve existing app data and setup.
+
+          ## Provenance
+
+          - Builder commit: \`$GITHUB_SHA\`
+          - SideStore upstream: \`$SIDESTORE_REF\`
+          - minimuxer upstream: \`$MINIMUXER_REF\`
+          - idevice: \`$IDEVICE_REF\`
+          - jktcp: \`$JKTCP_REF\`
+
+          Cellular-only refresh remains experimental and is not part of this stable release.
+          EOF
+
+      - name: Publish v1.0.3
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view v1.0.3 --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo 'Release v1.0.3 already exists; refusing to overwrite.'
+            exit 1
+          fi
+          gh release create v1.0.3 \
+            SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa \
+            SHA256SUMS.txt \
+            RELEASE_NOTES_v1.0.3.md \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title 'SideStore CoreDevice Auto-Refresh v1.0.3' \
+            --notes-file RELEASE_NOTES_v1.0.3.md
+
+      - name: Upload build evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: SideStore-v1.0.3-build-evidence
+          path: |
+            work/SideStore/build/logs
+            /tmp/v103-unzip.txt
+            /tmp/v103-strings.txt
+            SHA256SUMS.txt
+            RELEASE_NOTES_v1.0.3.md
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/prepare-v1.0.3.yml
+++ b/.github/workflows/prepare-v1.0.3.yml
@@ -1,0 +1,125 @@
+name: Prepare and publish standalone v1.0.3
+
+on:
+  push:
+    branches: [release/v1.0.3]
+    paths:
+      - '.github/workflows/prepare-v1.0.3.yml'
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  prepare-and-publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: release/v1.0.3
+          fetch-depth: 0
+
+      - name: Update standalone SideStore pins
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          p = Path('.github/workflows/build-current.yml')
+          text = p.read_text()
+          old_ss = 'SIDESTORE_REF: 394bb4eb331cb4afc23517af2fc847ec103af57f'
+          old_mux = 'MINIMUXER_REF: e0de126ec6773c02afe7d965def86ddffd79cbeb'
+          new_ss = 'SIDESTORE_REF: c6f28864dc99ed03ad35f2ca58967247036b7b53'
+          new_mux = 'MINIMUXER_REF: 9f038e5223a8cacf9d15beae7da6969d617ae1e8'
+          if old_ss not in text or old_mux not in text:
+              raise SystemExit('Expected old standalone pins were not found')
+          p.write_text(text.replace(old_ss, new_ss).replace(old_mux, new_mux))
+          PY
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add .github/workflows/build-current.yml
+          git commit -m 'Update standalone SideStore to 0.7.0 nightly'
+          git push origin HEAD:release/v1.0.3
+          echo "SOURCE_COMMIT=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Dispatch standalone build
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run build-current.yml --repo "$GITHUB_REPOSITORY" --ref release/v1.0.3
+          sleep 5
+          run_id="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow build-current.yml --branch release/v1.0.3 --event workflow_dispatch --limit 1 --json databaseId --jq '.[0].databaseId')"
+          test -n "$run_id"
+          echo "BUILD_RUN_ID=$run_id" >> "$GITHUB_ENV"
+          echo "Build run: $run_id"
+
+      - name: Wait for verified build
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run watch "$BUILD_RUN_ID" --repo "$GITHUB_REPOSITORY" --exit-status
+
+      - name: Download build artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release-artifact
+          gh run download "$BUILD_RUN_ID" --repo "$GITHUB_REPOSITORY" -n SideStore-v30-background-automation -D release-artifact
+          test -f release-artifact/SideStore.ipa
+          cp release-artifact/SideStore.ipa SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa
+          sha256sum SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa > SHA256SUMS.txt
+
+      - name: Write release notes
+        shell: bash
+        run: |
+          cat > RELEASE_NOTES_v1.0.3.md <<EOF
+          # SideStore CoreDevice Auto-Refresh v1.0.3
+
+          Standalone SideStore update based on the current SideStore 0.7.0 nightly code.
+
+          ## What's new
+
+          - Updated upstream SideStore to \`c6f28864dc99ed03ad35f2ca58967247036b7b53\` (0.7.0 nightly, 2026-09-11).
+          - Includes the newer SideStore/SideSign authentication path containing the upstream GSA 5XX mitigation.
+          - Retains this project's LocalDevVPN + CoreDevice same-device transport patches.
+          - Retains manual refresh, six-hour/daily/weekly background scheduling, refresh verification, history, and diagnostics.
+
+          ## Important
+
+          Cellular-only refresh remains experimental and is not part of this stable release.
+
+          Install this IPA over the existing matching standalone SideStore installation. Do not delete SideStore first if you want to preserve existing app data and setup.
+
+          ## Provenance
+
+          - Builder commit: \`$SOURCE_COMMIT\`
+          - SideStore upstream: \`c6f28864dc99ed03ad35f2ca58967247036b7b53\`
+          - minimuxer upstream: \`9f038e5223a8cacf9d15beae7da6969d617ae1e8\`
+          - Build run: \`$BUILD_RUN_ID\`
+
+          The attached \`SHA256SUMS.txt\` contains the checksum of the published IPA.
+          EOF
+
+      - name: Publish v1.0.3 release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view v1.0.3 --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo 'v1.0.3 already exists'
+            exit 1
+          fi
+          gh release create v1.0.3 \
+            SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa \
+            SHA256SUMS.txt \
+            RELEASE_NOTES_v1.0.3.md \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$SOURCE_COMMIT" \
+            --title 'SideStore CoreDevice Auto-Refresh v1.0.3' \
+            --notes-file RELEASE_NOTES_v1.0.3.md

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -11,6 +11,8 @@ permissions:
 
 jobs:
   dispatch:
+    # The v1.0.3 workflow owns its preflight, build and publication.
+    if: github.ref_name != 'release/v1.0.3'
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch current SideStore build for this release branch

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LiveContainer + SideStore Auto-Refresh
 
 [![Combined Build](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/workflows/livecontainer-build.yml/badge.svg)](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/workflows/livecontainer-build.yml)
-[![Standalone Build](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/workflows/build-current.yml/badge.svg)](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/workflows/build-current.yml)
+[![Standalone Build](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/workflows/build-publish-v1.0.3-r6.yml/badge.svg?branch=release%2Fv1.0.3)](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/workflows/build-publish-v1.0.3-r6.yml)
 [![Release](https://img.shields.io/github/v/release/NRG-Wardog/sidestore-auto-refresh)](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
@@ -51,9 +51,9 @@ These are actual screenshots from **LiveContainer + embedded SideStore v2.1.0**.
 
 The Guest Controls screen in v2.1.0 includes **Show Return Button**, **Start Collapsed**, **Use Custom Colors**, **Icon Color**, and **Button Background**.
 
-### Standalone v1.0.2
+### Standalone preview (v1.0.2 screenshots)
 
-These screenshots show the standalone SideStore v1.0.2 interface.
+These screenshots show the earlier standalone SideStore v1.0.2 interface. The current standalone download is v1.0.3, based on SideStore 0.7.0 nightly.
 
 <table>
 <tr>
@@ -79,13 +79,24 @@ These screenshots show the standalone SideStore v1.0.2 interface.
 | What you want | Use | Download |
 | --- | --- | --- |
 | LiveContainer with the modified SideStore built in | **Combined v2.1.0** | **[Download combined IPA](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/download/v2.1.0/LiveContainer-SideStore-AutoRefresh-v2.1.0.ipa)** |
-| SideStore only, with normal separately installed sideloaded apps | **Standalone v1.0.2** | **[Download standalone IPA](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/download/v1.0.2/SideStore-CoreDevice-AutoRefresh-v1.0.2.ipa)** |
+| SideStore only, with normal separately installed sideloaded apps | **Standalone v1.0.3** | **[Download standalone IPA](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/download/v1.0.3/SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa)** |
 
 If you want LiveContainer, install **v2.1.0**. SideStore is already embedded inside it, so do not install a separate SideStore copy for the same combined setup.
 
 **Combined:** [v2.1.0 release](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/tag/v2.1.0) | [SHA256SUMS](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/download/v2.1.0/SHA256SUMS.txt)
 
-**Standalone:** [v1.0.2 release](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/tag/v1.0.2) | [release notes](docs/RELEASE_NOTES_v1.0.2.md)
+**Standalone:** [v1.0.3 release](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/tag/v1.0.3) | [SHA256SUMS](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/download/v1.0.3/SHA256SUMS.txt) | [release notes](docs/RELEASE_NOTES_v1.0.3.md)
+
+## What's new in standalone v1.0.3?
+
+Standalone v1.0.3 updates the app to **SideStore 0.7.0 nightly**, including the newer **SideSign authentication path**.
+
+- Preserves LocalDevVPN → Lockdown/CoreDevice → RSD transport, manual refresh, scheduled refresh, history, retries, and verification.
+- Composite pairing records prefer Lockdown/CoreDevice, and this path works with LocalDevVPN without an additional IKEv2/IPsec interface.
+- Adapts signing instrumentation and background database startup to the SideStore 0.7 APIs.
+- Records self-refresh reconciliation success only after the database update succeeds.
+
+The IPA build, automated checks, and published-download verification passed. Device testing of this exact v1.0.3 build is still pending; earlier standalone device evidence is listed separately below. See the [release notes](docs/RELEASE_NOTES_v1.0.3.md) for exact source revisions and validation.
 
 ## What's new in v2.1.0?
 
@@ -196,9 +207,9 @@ Choose exactly one build for the setup you want:
 
 [Download `LiveContainer-SideStore-AutoRefresh-v2.1.0.ipa`](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/download/v2.1.0/LiveContainer-SideStore-AutoRefresh-v2.1.0.ipa)
 
-**Standalone SideStore v1.0.2**
+**Standalone SideStore v1.0.3**
 
-[Download `SideStore-CoreDevice-AutoRefresh-v1.0.2.ipa`](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/download/v1.0.2/SideStore-CoreDevice-AutoRefresh-v1.0.2.ipa)
+[Download `SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa`](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/download/v1.0.3/SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa)
 
 ### 2. Install iLoader and connect the device
 
@@ -375,7 +386,7 @@ The selected time is a **target deadline**, not an exact alarm. iOS controls whe
 
 ## Standalone setup (v1)
 
-Use this section only for **SideStore v1.0.2**.
+Use this section for **standalone SideStore v1.0.3**.
 
 ### 1. Open SideStore
 
@@ -521,8 +532,10 @@ The stable CoreDevice path preserves service TLS, contiguous CDTunnel writes, he
 
 | Scope | Current evidence |
 | --- | --- |
-| Standalone manual CoreDevice refresh | Verified on iPhone 12 / iOS 26.6.1 |
-| Standalone scheduled refresh with PC disconnected | Recorded proof is available in the verification report |
+| Standalone v1.0.3 build and packaging | CI passed; published IPA checksum, arm64 executable, background-task configuration, and 13 feature markers independently verified |
+| Standalone v1.0.3 device refresh | Device testing of this exact build is pending |
+| Earlier standalone manual CoreDevice refresh | Verified on iPhone 12 / iOS 26.6.1; this predates v1.0.3 |
+| Earlier standalone scheduled refresh with PC disconnected | Recorded proof predates v1.0.3 and is available in the verification report |
 | Combined v2.1.0 build and packaging | Combined CI run completed successfully |
 | v2.1.0 Guest Controls | Start Collapsed and custom colors are included in the published combined build |
 | Background scheduling | Best effort. iOS controls task launch timing |
@@ -539,11 +552,15 @@ A build completing, a background task starting, or a host handoff occurring is n
 - SHA-256: `6493e1e8c525a3b1ea343973bf199e30069f1c837f1a6175f3befa05d7a0eb50`
 - Release: [LiveContainer + SideStore Auto-Refresh v2.1.0](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/tag/v2.1.0)
 
-### v1.0.2 provenance
+### v1.0.3 provenance
 
-- IPA: `SideStore-CoreDevice-AutoRefresh-v1.0.2.ipa`
-- SHA-256: `120ba06c51d4d235743451b065968dc94f7c7374cacb955827860254e01b5a76`
-- Release: [SideStore CoreDevice Auto-Refresh v1.0.2](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/tag/v1.0.2)
+- Builder/tag commit: `07d52be7a49f6795b82f081ded2ec94eb44d50df`
+- Standalone CI run: [34613911507](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/runs/34613911507)
+- Upstream app version: SideStore `0.7.0`, build `0700`
+- IPA: `SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa`
+- SHA-256: `ab35772fe3209618c7bec302e315faea0a35b7ae280edfb9b5390d2aa62c8940`
+- Release: [SideStore CoreDevice Auto-Refresh v1.0.3](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/tag/v1.0.3)
+- Pinned sources and validation: [v1.0.3 release notes](docs/RELEASE_NOTES_v1.0.3.md)
 
 ## Build it yourself
 

--- a/docs/RELEASE_NOTES_v1.0.3.md
+++ b/docs/RELEASE_NOTES_v1.0.3.md
@@ -1,0 +1,52 @@
+# SideStore CoreDevice Auto-Refresh v1.0.3
+
+Standalone v1.0.3 updates the app to **SideStore 0.7.0 nightly** while preserving this project's LocalDevVPN → Lockdown/CoreDevice → RSD refresh path. Combined LiveContainer remains on its separate v2.1.0 release.
+
+[Download the IPA](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/download/v1.0.3/SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa) | [Release](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/tag/v1.0.3) | [SHA256SUMS](https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/download/v1.0.3/SHA256SUMS.txt)
+
+## Changes
+
+- Retains SideStore 0.7's authentication implementation, including its newer SideSign authentication path.
+- Adapts the new pairing parser so composite records prefer Lockdown/CoreDevice over RemotePairing.
+- Allows the CoreDevice path to use LocalDevVPN's tunnel without an additional IKEv2/IPsec interface.
+- Adapts the new signing block while retaining provisioning-profile checks and self-refresh markers.
+- Uses the new asynchronous database-startup API for scheduled refresh; the older combined build retains its callback API.
+- Prevents a database save error from producing a successful self-refresh reconciliation marker.
+- Preserves manual and scheduled refresh, history, retry/recovery behavior, cancellation, and verification diagnostics.
+- Corrects repository security checks so legitimate source filenames are accepted while sensitive artifact paths remain rejected across public branches, tags, and reachable history.
+
+## Pinned sources
+
+| Component | Commit |
+| --- | --- |
+| SideStore | `c6f28864dc99ed03ad35f2ca58967247036b7b53` |
+| minimuxer | `9f038e5223a8cacf9d15beae7da6969d617ae1e8` |
+| SideSign | `8385fab56e7bd5aea8110e1b85ab069a71e45ce0` |
+| idevice | `ebd7dadfc55d1c4facee3d11ecf5b28e20548b57` |
+| jktcp | `e674e1eee6d5943e13b1eba0bd24a9dd0b2fa020` |
+| Builder / release tag | `07d52be7a49f6795b82f081ded2ec94eb44d50df` |
+
+The app reports version `0.7.0`, build `0700`; `v1.0.3` identifies this project's standalone release.
+
+## Validation
+
+[Release CI run 34613911507](https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/runs/34613911507) completed successfully:
+
+- 83 repository tests passed in macOS CI. Two additional LiveContainer tests were skipped because their fixture lookup used a fixed local path; both subsequently passed locally against the pinned fixtures.
+- 14 Rust transport tests passed. The existing `local_tcp` and `handle_speed` tests remained filtered out.
+- The full standalone patch chain applied twice without further changes. Executable Swift checks covered pairing selection, both database-startup APIs, startup failures, task expiry, and self-refresh reconciliation.
+- SideStore authentication sources and the pinned SideSign dependency were verified unchanged by the patches.
+- The arm64 iOS archive, IPA packaging, and final feature-marker checks passed.
+- The published download independently passed SHA-256, ZIP integrity, app metadata, background-task configuration, and all 13 required feature-marker checks.
+
+IPA: `SideStore-CoreDevice-AutoRefresh-v1.0.3.ipa`
+
+SHA-256: `ab35772fe3209618c7bec302e315faea0a35b7ae280edfb9b5390d2aa62c8940`
+
+Device testing of this exact build is pending. Earlier standalone device evidence in [VERIFICATION.md](VERIFICATION.md) predates v1.0.3.
+
+## Updating
+
+Install the standalone IPA over the existing matching SideStore installation using the same Apple Account / Personal Team and identifiers. Keep the existing installation to preserve its data and configuration.
+
+Follow the [standalone setup instructions](../README.md#standalone-setup-v1). The supported setup uses Wi-Fi and the official LocalDevVPN. Cellular-only refresh remains experimental, and iOS controls when scheduled background tasks run.

--- a/scripts/adapt_sidestore_070_pairing.py
+++ b/scripts/adapt_sidestore_070_pairing.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Adapt SideStore 0.7.0 minimuxer layout to this project's Lockdown/CoreDevice policy."""
+
+from pathlib import Path
+import sys
+
+PAIRING_MARKER = "Composite records must use Lockdown/CoreDevice"
+UTUN_MARKER = "[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED"
+PAIRING_MODE_MARKER = "[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED"
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one anchor, found {count}")
+    return text.replace(old, new, 1)
+
+
+def patch_pairing(root: Path) -> None:
+    pairing_file = root / "Common" / "PairingFile.swift"
+    protocol_file = root / "Common" / "PairingProtocol.swift"
+
+    text = pairing_file.read_text(encoding="utf-8")
+    if PAIRING_MARKER not in text:
+        old = '''        let missingRP = RPPairingFile.missingKeys(in: plist)
+        if missingRP.isEmpty {
+            return .rppairing
+        }
+
+        let missingLockdown = LockdownPairingFile.missingKeys(in: plist)
+        if missingLockdown.isEmpty {
+            return .lockdown
+        }
+'''
+        new = '''        let missingLockdown = LockdownPairingFile.missingKeys(in: plist)
+        // Composite records must use Lockdown/CoreDevice; RemotePairing TCP is not
+        // viable for same-device operation on current iOS releases.
+        if missingLockdown.isEmpty {
+            return .lockdown
+        }
+
+        let missingRP = RPPairingFile.missingKeys(in: plist)
+        if missingRP.isEmpty {
+            return .rppairing
+        }
+'''
+        text = replace_once(text, old, new, "SideStore 0.7.0 pairing parser")
+        pairing_file.write_text(text, encoding="utf-8")
+
+    protocol = protocol_file.read_text(encoding="utf-8")
+    if PAIRING_MARKER not in protocol:
+        anchor = "import Foundation\n"
+        protocol = replace_once(
+            protocol,
+            anchor,
+            anchor + "\n// Composite records must use Lockdown/CoreDevice; parser policy lives in PairingFile.swift.\n",
+            "PairingProtocol.swift import",
+        )
+        protocol_file.write_text(protocol, encoding="utf-8")
+
+    final = pairing_file.read_text(encoding="utf-8")
+    lockdown = final.index("let missingLockdown = LockdownPairingFile.missingKeys(in: plist)")
+    remote = final.index("let missingRP = RPPairingFile.missingKeys(in: plist)", lockdown)
+    if lockdown >= remote:
+        raise SystemExit("Lockdown-first composite pairing policy was not established")
+
+
+def patch_localvpn_readiness(root: Path) -> None:
+    path = root / "Sources" / "MinimuxerImpl.swift"
+    text = path.read_text(encoding="utf-8")
+    if UTUN_MARKER in text:
+        return
+
+    old = '''                // check iKEv2 too if in lockdown mode and ios >= 26.4
+                if self.gateway.pairingFileType != .rppairing && !net.isIKEv2IPSecAvailable {
+                    if #available(iOS 26.4, *) {
+                        debugLog("[minimuxer] minimuxer not ready: no ipsec interface (required for lockdown on iOS 26.4+)")
+                        return .failure(.invalidVPN("utun is present but no ipsec/IKEv2 interface found — LocalDevVPN may not support the lockdown protocol on iOS 26.4+"))
+                    }
+                }
+'''
+    new = '''                // The CoreDevice Lockdown path uses the LocalDevVPN utun directly.
+                // An additional IKEv2/IPsec interface is not required by this build.
+                if self.gateway.pairingFileType != .rppairing {
+                    verboseLog("[SIDESTORE_COREDEVICE] LOCALVPN_UTUN_ACCEPTED transport=lockdown-coredevice")
+                }
+'''
+    text = replace_once(text, old, new, "SideStore 0.7.0 LocalDevVPN readiness")
+    path.write_text(text, encoding="utf-8")
+
+
+def patch_pairing_mode_logging(root: Path) -> None:
+    path = root / "DeviceGateway" / "idevice" / "IdeviceGateway.swift"
+    text = path.read_text(encoding="utf-8")
+    if PAIRING_MODE_MARKER in text:
+        return
+
+    old = '''            parsedPairingFile = try PairingFileParser.parse(content: pairingFileContent)
+            setPairingFileData(parsedPairingFile.rawData)
+            setPairingFileType(parsedPairingFile.mode)
+'''
+    new = '''            parsedPairingFile = try PairingFileParser.parse(content: pairingFileContent)
+            setPairingFileData(parsedPairingFile.rawData)
+            setPairingFileType(parsedPairingFile.mode)
+            debugLog("[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED mode=\\(parsedPairingFile.mode)")
+'''
+    text = replace_once(text, old, new, "SideStore 0.7.0 pairing mode logging")
+    path.write_text(text, encoding="utf-8")
+
+
+def main(root: Path) -> None:
+    patch_pairing(root)
+    patch_localvpn_readiness(root)
+    patch_pairing_mode_logging(root)
+    print("SideStore 0.7.0 adapted: Lockdown-first pairing, CoreDevice LocalDevVPN readiness, and pairing diagnostics")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: adapt_sidestore_070_pairing.py MINIMUXER_ROOT")
+    main(Path(sys.argv[1]))

--- a/scripts/adapt_sidestore_070_signing.py
+++ b/scripts/adapt_sidestore_070_signing.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Adapt SideStore 0.7.0 resign flow to this project's self-refresh verification marker."""
+
+from pathlib import Path
+import sys
+
+MARKER = "SIDESTORE_SIGN_PASS"
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one anchor, found {count}")
+    return text.replace(old, new, 1)
+
+
+def patch(root: Path) -> None:
+    path = root / "SideStore" / "Core" / "Operations" / "PipelineOperations" / "ResignAppOperation.swift"
+    text = path.read_text(encoding="utf-8")
+    if MARKER in text:
+        if text.count(MARKER) != 1 or "guard resignedAppBundle.provisioningProfile != nil" not in text:
+            raise SystemExit("SideStore signing marker exists without complete verification")
+        return
+
+    # SideStore 0.7.0 now keeps the URL returned by resignAppBundle().  Patch
+    # immediately after that new two-line signing block instead of trying to
+    # regex-match Swift interpolation syntax.  The exact anchor keeps this
+    # adapter fail-closed if upstream changes the signing flow again.
+    old = '''        let resignedAppURL = try await self.resignAppBundle(at: appBundleURL, team: team, certificate: certificate, profiles: Array(profiles.values))
+        guard let resignedAppBundle = ALTApplication(fileURL: resignedAppURL) else { throw OperationError.invalidApp }
+'''
+    new = old + '''        #if !targetEnvironment(simulator)
+        guard resignedAppBundle.provisioningProfile != nil else { throw OperationError.invalidApp }
+        #endif
+
+        if appBundle.isAltStoreApp {
+            self.debugLog("[SELF_REFRESH] SIDESTORE_SIGN_PASS bundle_id=\\(resignedAppBundle.bundleIdentifier)")
+        }
+'''
+    text = replace_once(text, old, new, "SideStore 0.7.0 resign flow")
+    path.write_text(text, encoding="utf-8")
+
+    final = path.read_text(encoding="utf-8")
+    if MARKER not in final or "provisioningProfile != nil" not in final:
+        raise SystemExit("SideStore 0.7.0 signing verification adaptation missing")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: adapt_sidestore_070_signing.py SIDESTORE_ROOT")
+    patch(Path(sys.argv[1]))
+    print("SideStore 0.7.0 resign flow adapted for self-refresh verification")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/patch_background_automation.py
+++ b/scripts/patch_background_automation.py
@@ -405,11 +405,47 @@ def replace_once(text: str, old: str, new: str, label: str) -> str:
     return text.replace(old, new, 1)
 
 
+DATABASE_SOURCE = "AltStore/Core/Model/DatabaseManager/DatabaseManager.swift"
+
+
+def database_start_block(sidestore: Path) -> str:
+    database = (sidestore / DATABASE_SOURCE).read_text(encoding="utf-8")
+    if "public func start() async throws\n" in database:
+        return r'''            Task { @MainActor in
+                do
+                {
+                    try await DatabaseManager.shared.start()
+                    beginRefresh()
+                }
+                catch
+                {
+                    debugLog("[AUTO_REFRESH] DATABASE_START_FAIL error=\(error.localizedDescription)")
+                    state.finish(success: false, detail: error.localizedDescription)
+                }
+            }'''
+    if "public func start(completionHandler: @escaping (Error?) -> Void)\n" in database:
+        return r'''            DatabaseManager.shared.start { error in
+                if let error
+                {
+                    debugLog("[AUTO_REFRESH] DATABASE_START_FAIL error=\(error.localizedDescription)")
+                    state.finish(success: false, detail: error.localizedDescription)
+                }
+                else
+                {
+                    beginRefresh()
+                }
+            }'''
+    die("Unsupported DatabaseManager.start API; update the background startup adapter")
+
+
 def patch_app_delegate(sidestore: Path) -> None:
     path = sidestore / "AltStore" / "AppDelegate.swift"
     text = path.read_text(encoding="utf-8")
+    database_start = database_start_block(sidestore)
     if MARKER in text:
         verify_app_delegate(text)
+        if database_start not in text:
+            die("AppDelegate database startup is outdated; use the pinned clean checkout")
         return
 
     text = replace_once(
@@ -830,17 +866,7 @@ private final class AutomaticRefreshTaskState: @unchecked Sendable
         }}
         else
         {{
-            DatabaseManager.shared.start {{ error in
-                if let error
-                {{
-                    debugLog("[AUTO_REFRESH] DATABASE_START_FAIL error=\\(error.localizedDescription)")
-                    state.finish(success: false, detail: error.localizedDescription)
-                }}
-                else
-                {{
-                    beginRefresh()
-                }}
-            }}
+{database_start}
         }}
     }}
     #endif
@@ -1019,7 +1045,7 @@ def patch_background_operation(sidestore: Path) -> None:
             throw error
         }
 
-        // Match AuthenticationOperation's cached-session and silentSignIn paths.
+        // Match the upstream cached-session and silent sign-in credential paths.
         // This checks available authentication material, not server validity.
         let auth = AuthManager.shared
         let hasPasswordCredentials = auth.currentAppleID != nil && auth.hasStoredPassword
@@ -1030,7 +1056,7 @@ def patch_background_operation(sidestore: Path) -> None:
             let error = NSError(
                 domain: "com.SideStore.Authentication",
                 code: 1004,
-                userInfo: [NSLocalizedDescriptionKey: "The refresh process cannot access saved sign-in credentials or a reusable session. Open embedded SideStore to check your account."]
+                userInfo: [NSLocalizedDescriptionKey: "The refresh process cannot access saved sign-in credentials or a reusable session. Open SideStore to check your account."]
             )
             debugLog("[AUTO_REFRESH] AUTH_PREFLIGHT_FAIL reason=no_accessible_authentication_path")
             self.scheduleFinishedRefreshingNotification(for: .failure(error), delay: 0)
@@ -1112,7 +1138,7 @@ def patch_background_operation(sidestore: Path) -> None:
         if let host = installedApps.first(where: { $0.bundleIdentifier == StoreApp.altstoreAppID }) {
             defaults.set(host.expirationDate, forKey: "liveContainerAutoRefreshHostPreviousExpiration")
         }
-        debugLog("[AUTO_REFRESH] HOST_REFRESH_HANDOFF_STARTED run_id=\\(refreshIdentifier)")
+        debugLog("[AUTO_REFRESH] HOST_REFRESH_HANDOFF_STARTED run_id=\(refreshIdentifier)")
     }
 
     private func persistAutomaticRefreshVerification(results: [String: Result<InstalledApp, Error>]) {
@@ -1121,13 +1147,13 @@ def patch_background_operation(sidestore: Path) -> None:
         for (bundleIdentifier, result) in results.sorted(by: { $0.key < $1.key }) {
             switch result {
             case .success(let app):
-                debugLog("[AUTO_REFRESH] REFRESH_VERIFIED bundle_id=\\(bundleIdentifier) refreshed_date=\\(app.refreshedDate) expiration_date=\\(app.expirationDate)")
+                debugLog("[AUTO_REFRESH] REFRESH_VERIFIED bundle_id=\(bundleIdentifier) refreshed_date=\(app.refreshedDate) expiration_date=\(app.expirationDate)")
                 serialized.append(["bundle_id": bundleIdentifier, "name": app.name,
                     "success": true, "refreshed_date": app.refreshedDate,
                     "expiration_date": app.expirationDate])
             case .failure(let error):
                 let nsError = error as NSError
-                debugLog("[AUTO_REFRESH] REFRESH_FAILED bundle_id=\\(bundleIdentifier) stage=refresh error_code=\\(nsError.code) error_domain=\\(nsError.domain) error=\\(error.localizedDescription)")
+                debugLog("[AUTO_REFRESH] REFRESH_FAILED bundle_id=\(bundleIdentifier) stage=refresh error_code=\(nsError.code) error_domain=\(nsError.domain) error=\(error.localizedDescription)")
                 serialized.append(["bundle_id": bundleIdentifier, "success": false,
                     "error_code": nsError.code, "error_domain": nsError.domain,
                     "error": error.localizedDescription])
@@ -1138,7 +1164,7 @@ def patch_background_operation(sidestore: Path) -> None:
             "results": serialized,
             "host_handoff": defaults.bool(forKey: "liveContainerAutoRefreshHostHandoff")],
             forKey: "liveContainerAutoRefreshVerification")
-        debugLog("[AUTO_REFRESH] VERIFICATION_MANIFEST_V1 run_id=\\(refreshIdentifier) result_count=\\(serialized.count)")
+        debugLog("[AUTO_REFRESH] VERIFICATION_MANIFEST_V1 run_id=\(refreshIdentifier) result_count=\(serialized.count)")
     }
 '''
         text = replace_once(

--- a/scripts/patch_combined_transport.py
+++ b/scripts/patch_combined_transport.py
@@ -204,8 +204,8 @@ def patch(minimuxer: Path):
                             r'''            setPairingFileType(parsedPairingFile.mode)
             debugLog("[SIDESTORE_COREDEVICE] PAIRING_MODE_SELECTED mode=\(parsedPairingFile.mode)")''',
                             "pairing selection diagnostic")
-        text = replace_once(text, "    private var coreDeviceProvider:",
-                            GATEWAY_STATE + "\n    private var coreDeviceProvider:", "batch state")
+        text = replace_once(text, "    private var usesCoreDevice: Bool { pairingFileType == .lockdown }",
+                            GATEWAY_STATE.rstrip(), "batch state")
         for detail in ("AFC_WRITE_BEGIN", "AFC_WRITE_RETURN", "AFC_FILE_OPEN_START",
                        "AFC_FILE_OPEN_PASS", "AFC_FILE_CLOSE_START", "AFC_FILE_CLOSE_PASS",
                        "STAGED_FILE_SIZE=", "STAGED_FILE_SIZE_MATCH=", "STAGING_WRITE_LOOP_DONE",

--- a/scripts/patch_sidestore_integration.py
+++ b/scripts/patch_sidestore_integration.py
@@ -434,11 +434,11 @@ func sideStoreTransportLog(_ message: UnsafePointer<CChar>?) {
 
     if modern:
         text = replace_once(text, "    private override init() {\n        try! super.init()",
+                            "    private var usesCoreDevice: Bool { pairingFileType == .lockdown }\n"
                             "    private let ffiQueueKey = DispatchSpecificKey<Bool>()\n\n"
                             "    private override init() {\n        try! super.init()\n"
                             "        ffiQueue.setSpecific(key: ffiQueueKey, value: true)",
                             "queue-aware invalidation initialization")
-
     ensure_coredevice = r'''    private func ensureCoreDeviceConnection() throws {
         if adapter != nil, handshake != nil, coreDeviceProvider != nil,
            tunnel_heartbeat_is_active() {
@@ -1062,12 +1062,14 @@ def patch_relaunch_verification(sidestore: Path) -> None:
     )
     text = replace_once(
         text,
-        """                    if let _ = InstalledApp.deserialize(from: jsonData, format: .json, context: context) {
-                        if context.hasChanges {
+        """                            debugLog("[AppDelegate] reconcileSelfReinstallation: Database successfully updated and saved.")
+                        }
+                    } else {
 """,
-        """                    if let _ = InstalledApp.deserialize(from: jsonData, format: .json, context: context) {
+        """                            debugLog("[AppDelegate] reconcileSelfReinstallation: Database successfully updated and saved.")
+                        }
                         didReconcile = true
-                        if context.hasChanges {
+                    } else {
 """,
         "reconcile success state",
     )

--- a/tests/standalone_pairing_policy.swift
+++ b/tests/standalone_pairing_policy.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+@main struct PairingPolicyCheck {
+    static func main() throws {
+        let lockdownKeys = ["WiFiMACAddress", "SystemBUID", "RootPrivateKey", "HostPrivateKey",
+                            "HostID", "RootCertificate", "UDID", "EscrowBag",
+                            "HostCertificate", "DeviceCertificate"]
+        let remoteKeys = ["private_key", "public_key", "identifier"]
+        func record(_ keys: [String]) -> [String: any Sendable] {
+            var value: [String: any Sendable] = [:]
+            for key in keys { value[key] = "synthetic-test-value" }
+            return value
+        }
+        for (keys, expected) in [(lockdownKeys, PairingProtocol.lockdown),
+                                 (remoteKeys, PairingProtocol.rppairing),
+                                 (lockdownKeys + remoteKeys, PairingProtocol.lockdown)] {
+            let mode = try PairingFileParser.validatePairingFile(from: record(keys))
+            precondition(mode == expected)
+            let xml = try PropertyListSerialization.data(fromPropertyList: record(keys), format: .xml, options: 0)
+            let parsed = try PairingFileParser.parse(content: String(decoding: xml, as: UTF8.self))
+            precondition(parsed.mode == expected)
+            precondition(parsed.rawData == xml)
+        }
+        for invalid in [nil, [:], record(["HostID"])] as [[String: any Sendable]?] {
+            do {
+                _ = try PairingFileParser.validatePairingFile(from: invalid)
+                fatalError("Incomplete pairing record accepted")
+            } catch is PairingError {}
+        }
+        print("SideStore 0.7.0 pairing policy PASS")
+    }
+}

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import importlib.util
 import os
 import platform
+import re
 import shutil
 import subprocess
 import tempfile
@@ -14,8 +15,8 @@ automation = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(automation)
 SWIFTC = os.environ.get("SWIFTC") or shutil.which("swiftc")
 SOURCE = Path(os.environ.get("SIDESTORE_TEST_SOURCE", ROOT.parent / "SideStore-source-timepicker"))
-REF = "394bb4eb331cb4afc23517af2fc847ec103af57f"
 FILES = ["AltStore/AppDelegate.swift", "AltStore/SceneDelegate.swift",
+         automation.DATABASE_SOURCE,
          "AltStore/Managing Apps/AppManager.swift",
          "AltStore/Info.plist", "AltStore/Settings/SettingsViewController.swift",
          "SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift",
@@ -23,6 +24,152 @@ FILES = ["AltStore/AppDelegate.swift", "AltStore/SceneDelegate.swift",
 
 
 class AutomationTests(unittest.TestCase):
+    def test_database_start_rejects_unknown_api(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            database = root / automation.DATABASE_SOURCE
+            database.parent.mkdir(parents=True)
+            database.write_text("public func start() -> Bool { true }", encoding="utf-8")
+            delegate = root / "AltStore/AppDelegate.swift"
+            delegate.write_text("unchanged", encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                automation.patch_app_delegate(root)
+            self.assertEqual(delegate.read_text(encoding="utf-8"), "unchanged")
+
+    @unittest.skipUnless((SOURCE / FILES[0]).is_file(), "Pinned SideStore checkout required")
+    def test_database_start_matches_pinned_apis(self):
+        sources = [SOURCE]
+        if os.environ.get("EMBEDDED_SIDESTORE_TEST_SOURCE"):
+            sources.append(Path(os.environ["EMBEDDED_SIDESTORE_TEST_SOURCE"]))
+        for source in sources:
+            with self.subTest(source=str(source)), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                for name in (FILES[0], automation.DATABASE_SOURCE):
+                    target = root / name
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    target.write_bytes((source / name).read_bytes())
+                automation.patch_app_delegate(root)
+                delegate = (root / FILES[0]).read_text(encoding="utf-8")
+                start = delegate.index("        if DatabaseManager.shared.isStarted",
+                                       delegate.index("    private func startAutomaticRefresh"))
+                end = delegate.index("\n    }\n    #endif", start)
+                startup = delegate[start:end]
+                database = (root / automation.DATABASE_SOURCE).read_text(encoding="utf-8")
+                signature = re.search(r"public func start\([^\n]+", database)[0]
+                modern = "async throws" in signature
+                self.assertEqual("try await DatabaseManager.shared.start()" in startup, modern)
+                self.assertEqual("DatabaseManager.shared.start { error in" in startup, not modern)
+                if not SWIFTC:
+                    continue
+                # Take the API declaration from upstream, not from a hand-written mock signature.
+                implementation = r'''
+        calls += 1
+        if suspend { await withCheckedContinuation { pending = $0 } }
+        if shouldFail { throw StartupError.failed }
+        isStarted = true
+''' if modern else r'''
+        calls += 1
+        let complete = {
+            self.isStarted = !self.shouldFail
+            completionHandler(self.shouldFail ? StartupError.failed : nil)
+        }
+        if suspend { pending = complete } else { complete() }
+'''
+                pending = "CheckedContinuation<Void, Never>" if modern else "(() -> Void)"
+                release = "pending?.resume()" if modern else "pending?()"
+                harness = r'''
+import Foundation
+enum StartupError: Error { case failed }
+func debugLog(_ message: String) {}
+final class DatabaseManager {
+    static var shared = DatabaseManager()
+    var isStarted = false
+    var calls = 0
+    var shouldFail = false
+    var suspend = false
+    var pending: PENDING_TYPE?
+    func release() { RELEASE_CALL; pending = nil }
+    UPSTREAM_SIGNATURE {
+UPSTREAM_IMPLEMENTATION
+    }
+}
+final class State {
+    var isFinished = false
+    var attempts = 0
+    var began = 0
+    var failure = ""
+    func finish(success: Bool, detail: String) {
+        guard !isFinished else { return }
+        precondition(!success)
+        failure = detail
+        isFinished = true
+    }
+}
+@MainActor final class Delegate {
+    func start(state: State) {
+        func beginRefresh() {
+            state.attempts += 1
+            guard !state.isFinished else { return }
+            state.began += 1
+        }
+GENERATED_STARTUP
+    }
+}
+@main struct Check {
+    @MainActor static func waitFor(_ condition: () -> Bool) async {
+        for _ in 0..<10000 {
+            if condition() { return }
+            await Task.yield()
+        }
+        preconditionFailure("Database startup did not complete")
+    }
+    @MainActor static func main() async {
+        let delegate = Delegate()
+        DatabaseManager.shared.isStarted = true
+        let already = State()
+        delegate.start(state: already)
+        precondition(already.began == 1 && DatabaseManager.shared.calls == 0)
+
+        DatabaseManager.shared = DatabaseManager()
+        let success = State()
+        delegate.start(state: success)
+        await waitFor { success.began == 1 }
+        precondition(DatabaseManager.shared.calls == 1 && success.failure.isEmpty)
+
+        DatabaseManager.shared = DatabaseManager()
+        DatabaseManager.shared.shouldFail = true
+        let failed = State()
+        delegate.start(state: failed)
+        await waitFor { failed.isFinished }
+        precondition(failed.began == 0 && !failed.failure.isEmpty)
+
+        DatabaseManager.shared = DatabaseManager()
+        DatabaseManager.shared.suspend = true
+        let expired = State()
+        delegate.start(state: expired)
+        await waitFor { DatabaseManager.shared.pending != nil }
+        expired.isFinished = true
+        DatabaseManager.shared.release()
+        await waitFor { expired.attempts == 1 }
+        precondition(expired.began == 0 && expired.failure.isEmpty)
+        print("Database startup behavior PASS")
+    }
+}
+'''
+                for key, value in (("PENDING_TYPE", pending), ("RELEASE_CALL", release),
+                                   ("UPSTREAM_SIGNATURE", signature),
+                                   ("UPSTREAM_IMPLEMENTATION", implementation),
+                                   ("GENERATED_STARTUP", startup)):
+                    harness = harness.replace(key, value)
+                path = root / "database-start.swift"
+                path.write_text(harness, encoding="utf-8")
+                binary = root / "database-start-test"
+                result = subprocess.run([SWIFTC, "-parse-as-library", str(path), "-o", str(binary)],
+                                        capture_output=True, text=True, timeout=120)
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
     def test_auth_preflight_accepts_upstream_credential_paths(self):
         source = (ROOT / "scripts/patch_background_automation.py").read_text(encoding="utf-8")
         self.assertNotIn("guard AuthManager.shared.isAuthenticated else", source)
@@ -182,13 +329,12 @@ print("Schedule date tests passed")
             subprocess.run([SWIFTC, str(path), "-o", str(binary)], check=True, capture_output=True, text=True)
             subprocess.run([str(binary)], check=True, capture_output=True, text=True)
 
-    @unittest.skipUnless((SOURCE / ".git").exists(), "Pinned SideStore checkout required")
+    @unittest.skipUnless((SOURCE / FILES[0]).is_file(), "Pinned SideStore checkout required")
     def test_patch_application_and_idempotence(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             for name in FILES:
-                contents = subprocess.run(["git", "-C", str(SOURCE), "show", f"{REF}:{name}"],
-                                         check=True, capture_output=True).stdout
+                contents = (SOURCE / name).read_bytes()
                 target = root / name
                 target.parent.mkdir(parents=True, exist_ok=True)
                 target.write_bytes(contents)

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -16,11 +16,47 @@ REQUIRED_SCRIPTS = {
     "patch_sidestore_integration.py",
     "patch_background_automation.py",
     "patch_local_idevice_package.py",
+    "adapt_sidestore_070_pairing.py",
+    "adapt_sidestore_070_signing.py",
 }
 LIVE_CONTAINER_SCRIPT = "patch_livecontainer_autorefresh.py"
 LIVE_CONTAINER_STARTUP_SCRIPT = "patch_embedded_sidestore_startup.py"
 COMBINED_REFRESH_SCRIPT = "patch_combined_refresh_contract.py"
 EMBEDDED_KEYCHAIN_SCRIPT = "patch_embedded_keychain.py"
+
+_SENSITIVE_ARTIFACT_SUFFIXES = {".p12", ".pfx", ".der", ".pem", ".key"}
+_SENSITIVE_NAMES = re.compile(
+    r"(?i)(pairingfile|rppairing|client_(cert|key)|lockdowndirectdiag|"
+    r"(?:^|[/_.-])pairing(?:[/_.-]|$))"
+)
+_PUBLIC_SOURCE_DIRS = {"scripts", "tests", "docs"}
+_PUBLIC_SOURCE_SUFFIXES = {
+    ".c", ".cpp", ".h", ".hpp", ".js", ".md", ".rst", ".py", ".rs", ".swift", ".ts", ".tsx"
+}
+
+
+def _is_sensitive_reachable_path(path: str) -> bool:
+    """Classify Git path output without treating source identifiers as secrets."""
+    normalized = path.replace("\\", "/").strip("/")
+    if not normalized:
+        return False
+    parts = normalized.split("/")
+    basename = parts[-1].lower()
+    suffix = Path(basename).suffix
+
+    # These formats are private signing/pairing material wherever they occur.
+    if suffix in _SENSITIVE_ARTIFACT_SUFFIXES:
+        return True
+    # Source identifiers may mention pairing. Serialized data (including JSON
+    # and plist) and private material never inherit the source exemption.
+    if _SENSITIVE_NAMES.search(normalized):
+        is_public_source = (
+            len(parts) > 1
+            and parts[0].lower() in _PUBLIC_SOURCE_DIRS
+            and suffix in _PUBLIC_SOURCE_SUFFIXES
+        )
+        return not is_public_source
+    return False
 
 
 class RepositoryTests(unittest.TestCase):
@@ -85,17 +121,36 @@ class RepositoryTests(unittest.TestCase):
         self.assertNotIn(chr(0x2014), source)
 
     def test_no_sensitive_paths_are_reachable(self):
+        # Retain the audit of every reachable ref, including deleted files in
+        # history. A clone containing private investigation refs must fail.
         result = subprocess.run(
-            ["git", "rev-list", "--objects", "--all"],
+            ["git", "-c", "core.quotePath=false", "rev-list", "--objects", "--all"],
             cwd=ROOT,
             check=True,
             capture_output=True,
             text=True,
         )
-        self.assertNotRegex(
-            result.stdout,
-            r"(?i)(pairingFile|rppairing|client\.p12|client_(cert|key)|LockdownDirectDiag|\.der$)",
+        reachable_paths = [parts[1] for line in result.stdout.splitlines()
+                           if len(parts := line.split(maxsplit=1)) == 2]
+        self.assertFalse(
+            [path for path in reachable_paths if _is_sensitive_reachable_path(path)],
+            "reachable repository contains sensitive artifact paths",
         )
+
+    def test_sensitive_path_classifier_preserves_security_boundary(self):
+        self.assertFalse(_is_sensitive_reachable_path("scripts/adapt_sidestore_070_pairing.py"))
+        self.assertFalse(_is_sensitive_reachable_path("tests/PairingFile.swift"))
+        self.assertTrue(_is_sensitive_reachable_path("PairingFile"))
+        self.assertTrue(_is_sensitive_reachable_path("private/client_cert.pem"))
+        self.assertTrue(_is_sensitive_reachable_path("scripts/client.p12"))
+        self.assertTrue(_is_sensitive_reachable_path("diagnostics/LockdownDirectDiag.log"))
+        self.assertTrue(_is_sensitive_reachable_path("docs/export.der"))
+        for path in ("scripts/pairingFile.json", "tests/rppairing.plist",
+                     "data/device.pairing", "backups/pairingFile.plist.old",
+                     "exports/client_key.backup", "LockdownDirectDiag/output.log",
+                     "docs/CLIENT.P12", "scripts/key.pem", "data/phone.pfx"):
+            with self.subTest(path=path):
+                self.assertTrue(_is_sensitive_reachable_path(path))
 
     def test_public_docs_do_not_expose_known_private_network_details(self):
         """Generic RFC1918 examples are allowed; known diagnostic addresses are not."""

--- a/tests/test_sidestore_070.py
+++ b/tests/test_sidestore_070.py
@@ -1,0 +1,175 @@
+"""Execute the standalone migration against the exact source used by CI."""
+from pathlib import Path
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+import adapt_sidestore_070_signing as signing
+from test_combined_transport import function, snapshot
+
+RESIGN = "SideStore/Core/Operations/PipelineOperations/ResignAppOperation.swift"
+SIGNING_BLOCK = r'''        let resignedAppURL = try await self.resignAppBundle(at: appBundleURL, team: team, certificate: certificate, profiles: Array(profiles.values))
+        guard let resignedAppBundle = ALTApplication(fileURL: resignedAppURL) else { throw OperationError.invalidApp }
+
+        self.debugLog("[ResignAppOperation] Resigned app \(self.context.bundleIdentifier) to \(resignedAppBundle.bundleIdentifier).")
+'''
+
+
+class SigningAdapterTests(unittest.TestCase):
+    def test_whitespace_and_literal_interpolation_and_idempotence(self):
+        for blank in ("\n", "        \n", "\t\n"):
+            with self.subTest(blank=repr(blank)), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                path = root / RESIGN
+                path.parent.mkdir(parents=True)
+                path.write_text(SIGNING_BLOCK.replace("\n\n", "\n" + blank), encoding="utf-8")
+                signing.patch(root)
+                result = path.read_text(encoding="utf-8")
+                self.assertEqual(result.count("SIDESTORE_SIGN_PASS"), 1)
+                self.assertIn(r"bundle_id=\(resignedAppBundle.bundleIdentifier)", result)
+                self.assertIn("provisioningProfile != nil", result)
+                signing.patch(root)
+                self.assertEqual(path.read_text(encoding="utf-8"), result)
+
+    def test_changed_or_duplicate_signing_statement_fails_without_writing(self):
+        for source in (SIGNING_BLOCK * 2, SIGNING_BLOCK.replace("try await", "try? await")):
+            with tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                path = root / RESIGN
+                path.parent.mkdir(parents=True)
+                path.write_text(source, encoding="utf-8")
+                with self.assertRaises(SystemExit):
+                    signing.patch(root)
+                self.assertEqual(path.read_text(encoding="utf-8"), source)
+
+
+class StandaloneMigrationTests(unittest.TestCase):
+    def check_reconciliation(self, root, swiftc):
+        delegate = (root / "AltStore/AppDelegate.swift").read_text(encoding="utf-8")
+        start = delegate.index("            var didSave = false")
+        end = delegate.index("            if didSave {", start)
+        block = delegate[start:end]
+        self.assertLess(block.index("try context.save()"), block.index("didReconcile = true"))
+        if not swiftc:
+            return
+        harness = r'''
+import Foundation
+func debugLog(_ message: String) {}
+enum SaveError: Error { case failed }
+final class Context {
+    let hasChanges: Bool
+    let valid: Bool
+    let saveFails: Bool
+    init(changes: Bool, valid: Bool, saveFails: Bool) {
+        self.hasChanges = changes
+        self.valid = valid
+        self.saveFails = saveFails
+    }
+    func performAndWait(_ action: () -> Void) { action() }
+    func save() throws { if saveFails { throw SaveError.failed } }
+}
+struct InstalledApp {
+    enum Format { case json }
+    static func deserialize(from: Data, format: Format, context: Context) -> InstalledApp? {
+        context.valid ? InstalledApp() : nil
+    }
+}
+func reconcile(changes: Bool, valid: Bool = true, saveFails: Bool = false) -> Bool {
+    let context = Context(changes: changes, valid: valid, saveFails: saveFails)
+    let jsonData = Data()
+RECONCILE_BLOCK
+    return didReconcile
+}
+precondition(reconcile(changes: true))
+precondition(reconcile(changes: false))
+precondition(!reconcile(changes: true, valid: false))
+precondition(!reconcile(changes: true, saveFails: true))
+print("Self-refresh reconciliation behavior PASS")
+'''.replace("RECONCILE_BLOCK", block)
+        path = root / "reconciliation-check.swift"
+        path.write_text(harness, encoding="utf-8")
+        binary = root / "reconciliation-check"
+        result = subprocess.run([swiftc, str(path), "-o", str(binary)],
+                                capture_output=True, text=True, timeout=120)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_full_patch_chain_on_pinned_source(self):
+        source = os.environ.get("SIDESTORE_070_TEST_SOURCE")
+        if not source:
+            self.skipTest("Set SIDESTORE_070_TEST_SOURCE to the pinned standalone source")
+        source = Path(source)
+        self.assertTrue((source / RESIGN).is_file())
+        with tempfile.TemporaryDirectory(prefix="standalone-070-") as directory:
+            root = Path(directory) / "SideStore"
+            shutil.copytree(source, root, ignore=shutil.ignore_patterns(
+                ".git", ".build", "build", "*.xcframework", "*.ipa"))
+            mux = root / "Dependencies/minimuxer"
+            commands = [
+                ("adapt_sidestore_070_pairing.py", mux),
+                ("adapt_sidestore_070_signing.py", root),
+                ("patch_sidestore_integration.py", mux, root),
+                ("patch_background_automation.py", root),
+                ("patch_local_idevice_package.py", mux),
+            ]
+            before = snapshot(root)
+            for iteration in range(2):
+                for script, *args in commands:
+                    result = subprocess.run([sys.executable, str(ROOT / "scripts" / script),
+                                             *map(str, args)], capture_output=True, text=True)
+                    self.assertEqual(result.returncode, 0, script + "\n" + result.stdout + result.stderr)
+                current = snapshot(root)
+                if iteration == 0:
+                    first = current
+                else:
+                    self.assertEqual(first, current, "Full patch chain must be idempotent")
+            gateway = (mux / "DeviceGateway/idevice/IdeviceGateway.swift").read_text(encoding="utf-8")
+            self.assertEqual(gateway.count("private var usesCoreDevice:"), 1)
+            connection = function(gateway, "ensureCoreDeviceConnection")
+            self.assertIn("do {", connection)
+            self.assertIn("catch {", connection)
+            self.assertIn("tunnel_create_usb(provider, &adapter, &handshake)", connection)
+            self.assertRegex(gateway, r"private var usesCoreDevice: Bool \{ pairingFileType == .lockdown \}")
+            self.assertIn("if usesCoreDevice {", function(gateway, "ensureRPConnection"))
+            self.assertNotIn("isRPPairing", gateway)
+            # Preserve the actual 0.7 authentication implementation, not just its imports.
+            for path, data in before.items():
+                if path.startswith(("SideStore/Core/Auth/", "Dependencies/SideSign/")):
+                    self.assertEqual(current[path], data, path)
+            background = (root / "SideStore/Core/Operations/StandaloneOperations/BackgroundRefreshAppsOperation.swift").read_text(encoding="utf-8")
+            self.assertIn("hasPasswordCredentials || hasTokenCredentials || hasReusableSession", background)
+            self.assertIn("persistAutomaticRefreshVerification(results: results)", background)
+            self.assertIn("group?.cancel()", background)
+            for line in background.splitlines():
+                if 'debugLog("[AUTO_REFRESH]' in line:
+                    self.assertNotIn(r"\\(", line, "Diagnostic values must use Swift interpolation")
+            # Swift parsing runs on macOS CI before any IPA archive is started.
+            swiftc = shutil.which("swiftc")
+            if os.environ.get("REQUIRE_SWIFT_070_CHECKS") == "1":
+                self.assertIsNotNone(swiftc, "CI must execute Swift validation")
+            self.check_reconciliation(root, swiftc)
+            if swiftc:
+                binary = root / "pairing-policy-test"
+                result = subprocess.run([swiftc, str(mux / "Common/MinimuxerConstants.swift"),
+                                         str(mux / "Common/PairingProtocol.swift"),
+                                         str(mux / "Common/PairingFile.swift"),
+                                         str(ROOT / "tests/standalone_pairing_policy.swift"),
+                                         "-o", str(binary)], capture_output=True, text=True)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                subprocess.run([str(binary)], check=True, timeout=30)
+                for path, data in current.items():
+                    if path.endswith(".swift") and before.get(path) != data:
+                        result = subprocess.run([swiftc, "-frontend", "-parse", str(root / path)],
+                                                capture_output=True, text=True)
+                        self.assertEqual(result.returncode, 0, path + "\n" + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Updates the standalone build to the pinned SideStore 0.7.0 nightly and brings the published v1.0.3 implementation onto main. LocalDevVPN → Lockdown/CoreDevice → RSD, manual and scheduled refresh, history, retries, and the upstream SideSign authentication implementation are retained.

The migration adapts the moved pairing parser and signing block, repairs CoreDevice routing, uses the correct asynchronous database-startup API, and prevents failed database saves from reporting successful self-refresh reconciliation. Repository checks distinguish source filenames from sensitive artifacts and scan reachable history.

The README now links to the v1.0.3 IPA, checksum, successful build, and detailed release notes. It records the exact source pins and distinguishes the new build's automated validation from earlier device evidence. Combined v2.1.0 documentation and the version labels on older screenshots are preserved.

Validation:

- Published release: https://github.com/NRG-Wardog/sidestore-auto-refresh/releases/tag/v1.0.3
- Successful build and IPA verification: https://github.com/NRG-Wardog/sidestore-auto-refresh/actions/runs/34613911507
- 83 repository tests passed in macOS CI; both fixture-dependent tests skipped there passed locally against pinned sources. All 14 selected Rust tests passed.
- The downloaded IPA independently passed checksum, ZIP integrity, arm64 metadata, background-task configuration, and all 13 feature-marker checks.
- Documentation links/images and `git diff --check` pass. The documentation update does not change the implementation used to build the published IPA.
- Device testing of the exact v1.0.3 IPA remains pending.
